### PR TITLE
view expect location_status to be code

### DIFF
--- a/admin/controllers/Locations.php
+++ b/admin/controllers/Locations.php
@@ -107,7 +107,7 @@ class Locations extends Admin_Controller {
 				'location_telephone'	=> $result['location_telephone'],
 				'location_lat'			=> $result['location_lat'],
 				'location_lng'			=> $result['location_lng'],
-				'location_status'		=> ($result['location_status'] === '1') ? $this->lang->line('text_enabled') : $this->lang->line('text_disabled'),
+				'location_status'		=> isset($result['location_status']) ? $result['location_status'] : '1',
 				'default'				=> $default,
 				'edit' 					=> site_url('locations/edit?id=' . $result['location_id'])
 			);


### PR DESCRIPTION
Admin location status page always shows status "Disabled" even though they are disabled. View expects location_status to be 0/1 instead of string description.