### PR TITLE
Guest checkout error. missing table

### DIFF
--- a/app/admin/models/Customers_model.php
+++ b/app/admin/models/Customers_model.php
@@ -217,18 +217,6 @@ class Customers_model extends AuthUserModel
                     if ($row['order_type'] == '1' AND !empty($row['address_id'])) {
                         Addresses_model::where('address_id', $row['address_id'])->update($update);
                     }
-
-                    // @todo: move to paypal extension
-                    if (!empty($row['payment'])) {
-                        switch ($row['payment']) { 
-                            case 'paypalexpress':
-                                DB::table('pp_payments')->where('order_id', $row['order_id'])
-                                  ->update(['customer_id' => $customer_id]);
-                                break;
-                            default:
-                                // Do any other payment methods need any actions done here?
-                        }
-                    }
                 }
             }
 

--- a/app/admin/models/Customers_model.php
+++ b/app/admin/models/Customers_model.php
@@ -220,8 +220,14 @@ class Customers_model extends AuthUserModel
 
                     // @todo: move to paypal extension
                     if (!empty($row['payment'])) {
-                        DB::table('pp_payments')->where('order_id', $row['order_id'])
-                          ->update(['customer_id' => $customer_id]);
+                        switch ($row['payment']) { 
+                            case 'paypalexpress':
+                                DB::table('pp_payments')->where('order_id', $row['order_id'])
+                                  ->update(['customer_id' => $customer_id]);
+                                break;
+                            default:
+                                // Do any other payment methods need any actions done here?
+                        }
                     }
                 }
             }


### PR DESCRIPTION
It would appear that when you try to register an account after using guest checkout, the script tries to update a nonexistant table which (i assume) is resevred and used for detailed paypal payment data.

I have left an open ended Switch as obviously something needed to be done for paypay payments which has yet to be moved into the paypal model.

I donnt know what you inteneded long term approch for this will be, a call to the payment functions model for "post guest checkout" actions?