### PR TITLE
Unable to load admin login

### DIFF
--- a/app/admin/classes/User.php
+++ b/app/admin/classes/User.php
@@ -55,7 +55,7 @@ class User extends Manager
 
     public function getId()
     {
-        return $this->user()->user_id;
+        return $this->user()->user_id ?? NULL;
     }
 
     public function getUserName()


### PR DESCRIPTION
Error message
 	ErrorException: Trying to get property 'user_id' of non-object
in /.../public_html/v3/app/admin/classes/User.php:58

As the user variable has no object yet, it cannot get the property, catching scenario with a Null coalescing operator and I will investigate further at a later date.

This has now allowed me to log in to the admin panel