### PR TITLE
Add menu item option quantity type

### DIFF
--- a/app/admin/language/en/lang.php
+++ b/app/admin/language/en/lang.php
@@ -617,6 +617,7 @@ return [
         'text_select' => 'Select',
         'text_radio' => 'Radio',
         'text_checkbox' => 'Checkbox',
+        'text_quantity' => 'Quantity',
         'is_required' => 'is required',
         'is_not_required' => 'is not required',
         'text_option' => 'Option',

--- a/app/admin/models/Menu_options_model.php
+++ b/app/admin/models/Menu_options_model.php
@@ -57,6 +57,7 @@ class Menu_options_model extends Model
             'radio' => 'lang:admin::lang.menu_options.text_radio',
             'checkbox' => 'lang:admin::lang.menu_options.text_checkbox',
             'select' => 'lang:admin::lang.menu_options.text_select',
+            'quantity' => 'lang:admin::lang.menu_options.text_quantity',
         ];
     }
 

--- a/app/admin/views/menus/form/menu_options.php
+++ b/app/admin/views/menus/form/menu_options.php
@@ -23,6 +23,11 @@
                 title="<?= sprintf(lang('admin::lang.menu_options.text_option_summary'), $item->display_type) ?>"
                 class="fa fa-caret-square-down text-muted"
             ></i>
+        <?php } elseif ($item->display_type == 'quantity') { ?>
+            <i
+                title="<?= sprintf(lang('admin::lang.menu_options.text_option_summary'), $item->display_type) ?>"
+                class="fa fa-plus-square text-muted"
+            ></i>
         <?php } else { ?>
             <?= sprintf(lang('admin::lang.menu_options.text_option_summary'), $item->display_type); ?>
         <?php } ?>

--- a/app/admin/views/orders/form/order_menus.php
+++ b/app/admin/views/orders/form/order_menus.php
@@ -21,9 +21,11 @@ $orderTotals = $model->getOrderTotals();
                     <?php if ($menuItemOptions = $menuItemsOptions->get($menuItem->order_menu_id)) { ?>
                         <ul class="list-unstyled">
                             <?php foreach ($menuItemOptions as $menuItemOption) { ?>
-                                <li><?= $menuItemOption->order_option_name; ?>&nbsp;
+                                <li>
+                                    <?= $menuItemOption->quantity; ?>x
+                                    <?= $menuItemOption->order_option_name; ?>&nbsp;
                                     <?php if ($menuItemOption->order_option_price > 0) { ?>
-                                        (<?= currency_format($menuItemOption->order_option_price); ?>)
+                                        (<?= currency_format($menuItemOption->quantity*$menuItemOption->order_option_price); ?>)
                                     <?php } ?>
                                 </li>
                             <?php } ?>

--- a/app/admin/views/orders/invoice.php
+++ b/app/admin/views/orders/invoice.php
@@ -109,9 +109,10 @@
                                     <div>
                                         <?php foreach ($menuItemOptions as $menuItemOption) { ?>
                                             <small>
+                                                <?= $menuItemOption->quantity; ?>x
                                                 <?= $menuItemOption->order_option_name; ?>
                                                 =
-                                                <?= currency_format($menuItemOption->order_option_price); ?>
+                                                <?= currency_format($menuItemOption->quantity*$menuItemOption->order_option_price); ?>
                                             </small><br>
                                         <?php } ?>
                                     </div>


### PR DESCRIPTION
Add a new menu item option type: Quantity
This allows selection of quantities of each option (eg choose 6 of the options, and they can make up the quantity of 6 from various amounts of the option).

Affects core (this PR)
Affects cart (https://github.com/tastyigniter/ti-ext-cart/pull/9)
Affects theme-orange (https://github.com/tastyigniter/ti-theme-orange/pull/7)

There may be other places this needs to update (eg mail partials) as this means we need to care about the quantity option on menu item options, when previously it could be assume to be 1 always.