### PR TITLE
Added orderId to createHistory on coupon history

### DIFF
--- a/app/admin/models/Coupons_history_model.php
+++ b/app/admin/models/Coupons_history_model.php
@@ -69,12 +69,13 @@ class Coupons_history_model extends Model
      * @param \Admin\Models\Customers_model $customer
      * @return \Admin\Models\Coupons_history_model|bool
      */
-    public static function createHistory($couponCondition, $customer)
+    public static function createHistory($couponCondition, $customer, $orderId)
     {
         if (!$coupon = $couponCondition->getModel())
             return FALSE;
 
         $model = new static;
+        $model->order_id = $orderId ? $orderId : 0;
         $model->customer_id = $customer ? $customer->getKey() : 0;
         $model->coupon_id = $coupon->coupon_id;
         $model->code = $coupon->code;

--- a/app/admin/traits/ManagesOrderItems.php
+++ b/app/admin/traits/ManagesOrderItems.php
@@ -216,7 +216,8 @@ trait ManagesOrderItems
         if (!$this->exists)
             return FALSE;
 
-        return Coupons_history_model::createHistory($couponCondition, $customer);
+        $orderId = $this->getKey();
+        return Coupons_history_model::createHistory($couponCondition, $customer, $orderId);
     }
 
     public function orderMenusQuery()


### PR DESCRIPTION
Currently coupon history all return order id's of 0.

This should add the corresponding order id to a coupon history.