### PR TITLE
Properly translated order_type in emails

### DIFF
--- a/app/admin/models/Orders_model.php
+++ b/app/admin/models/Orders_model.php
@@ -325,7 +325,7 @@ class Orders_model extends Model
         $data['telephone'] = $model->telephone;
         $data['order_comment'] = $model->comment;
 
-        $data['order_type'] = $model->order_type;
+        $data['order_type'] = lang('admin::lang.orders.text_'.$model->order_type);
         $data['order_time'] = $model->order_time.' '.$model->order_date->format('d M');
         $data['order_date'] = $model->date_added->format('d M y');
 


### PR DESCRIPTION
Order type in emails send to a customer and to admin that contained {order_type} var doesn't get translated. This little modification changes this.