### PR TITLE
Change implementation of extensions permissions

### DIFF
--- a/app/system/controllers/Extensions.php
+++ b/app/system/controllers/Extensions.php
@@ -62,9 +62,6 @@ class Extensions extends \Admin\Classes\AdminController
 
     public function edit($action, $vendor = null, $extension = null, $context = null)
     {
-        if (!$this->getUser()->hasPermission('Site.Settings'))
-            throw new SystemException(lang('admin::lang.alert_user_restricted'));
-
         AdminMenu::setContext('settings', 'system');
 
         try {

--- a/app/system/controllers/Extensions.php
+++ b/app/system/controllers/Extensions.php
@@ -62,6 +62,9 @@ class Extensions extends \Admin\Classes\AdminController
 
     public function edit($action, $vendor = null, $extension = null, $context = null)
     {
+        if (!$this->getUser()->hasPermission('Site.Settings'))        
+            throw new SystemException(lang('admin::lang.alert_user_restricted'));
+
         AdminMenu::setContext('settings', 'system');
 
         try {

--- a/app/system/controllers/Extensions.php
+++ b/app/system/controllers/Extensions.php
@@ -31,7 +31,7 @@ class Extensions extends \Admin\Classes\AdminController
         ],
     ];
 
-    protected $requiredPermissions = 'Admin.*';
+    protected $requiredPermissions = ['Admin.Extensions', 'Site.Settings'];
 
     /**
      * @var \Admin\Widgets\Form

--- a/app/system/controllers/Extensions.php
+++ b/app/system/controllers/Extensions.php
@@ -31,7 +31,7 @@ class Extensions extends \Admin\Classes\AdminController
         ],
     ];
 
-    protected $requiredPermissions = 'Admin.Extensions';
+    protected $requiredPermissions = 'Admin.*';
 
     /**
      * @var \Admin\Widgets\Form
@@ -52,6 +52,9 @@ class Extensions extends \Admin\Classes\AdminController
 
     public function index()
     {
+        if (!$this->getUser()->hasPermission('Admin.Extensions'))
+            throw new SystemException(lang('admin::lang.alert_user_restricted'));
+        
         Extensions_model::syncAll();
 
         $this->asExtension('ListController')->index();
@@ -59,6 +62,9 @@ class Extensions extends \Admin\Classes\AdminController
 
     public function edit($action, $vendor = null, $extension = null, $context = null)
     {
+        if (!$this->getUser()->hasPermission('Site.Settings'))
+            throw new SystemException(lang('admin::lang.alert_user_restricted'));
+
         AdminMenu::setContext('settings', 'system');
 
         try {
@@ -89,6 +95,9 @@ class Extensions extends \Admin\Classes\AdminController
 
     public function delete($context, $extensionCode = null)
     {
+        if (!$this->getUser()->hasPermission('Admin.Extensions'))
+            throw new SystemException(lang('admin::lang.alert_user_restricted'));
+
         try {
             $pageTitle = lang('system::lang.extensions.text_delete_title');
             Template::setTitle($pageTitle);


### PR DESCRIPTION
Allow the user to manage the settings for an extension (via settings page), if they have permission to access Site.Settings and permissions on the setting itself.

This amends current behaviour which requires user to have permission on Admin.Extensions to be able to access and modify Settings for an extension, which is incorrect.