### PR TITLE
Limit orders admin fields

### DIFF
--- a/app/admin/language/en/lang.php
+++ b/app/admin/language/en/lang.php
@@ -510,7 +510,6 @@ return [
         'label_image' => 'Image',
         'label_limit_orders' => 'Limit Order Count',
         'label_limit_orders_count' => 'Maximum Orders Per Interval',
-        'label_limit_orders_interval' => 'Limit Orders Time Interval',
         'label_offer_delivery' => 'Offer Delivery',
         'label_offer_collection' => 'Offer Pick-up',
         'label_delivery_time_interval' => 'Delivery Time Interval',

--- a/app/admin/language/en/lang.php
+++ b/app/admin/language/en/lang.php
@@ -508,6 +508,9 @@ return [
         'label_telephone' => 'Telephone',
         'label_permalink_slug' => 'Slug',
         'label_image' => 'Image',
+        'label_limit_orders' => 'Limit Order Count',
+        'label_limit_orders_count' => 'Maximum Orders Per Interval',
+        'label_limit_orders_interval' => 'Limit Orders Time Interval',
         'label_offer_delivery' => 'Offer Delivery',
         'label_offer_collection' => 'Offer Pick-up',
         'label_delivery_time_interval' => 'Delivery Time Interval',
@@ -555,6 +558,7 @@ return [
 
         'help_permalink_disabled' => 'Permalink is disabled when single location mode is activated.',
         'help_image' => 'Select a logo for this location.',
+        'help_limit_orders_interval' => 'Set the minutes between each limitation timeslot.',
         'help_delivery_time_interval' => 'Set the minutes between each delivery order time available to your customer.',
         'help_collection_time_interval' => 'Set the minutes between each pick-up order time available to your customer.',
         'help_delivery_lead_time' => 'Set in minutes the average time it takes an order to be delivered after being placed',

--- a/app/admin/models/config/locations_model.php
+++ b/app/admin/models/config/locations_model.php
@@ -342,19 +342,6 @@ $config['form']['tabs'] = [
                 'condition' => 'checked',
             ],
         ],
-        'options[limit_orders_interval]' => [
-            'label' => 'lang:admin::lang.locations.label_limit_orders_interval',
-            'tab' => 'lang:admin::lang.locations.text_tab_data',
-            'default' => 30,
-            'type' => 'number',
-            'span' => 'right',
-            'comment' => 'lang:admin::lang.locations.help_limit_orders_interval',
-            'trigger' => [
-                'action' => 'enable',
-                'field' => 'options[limit_orders]',
-                'condition' => 'checked',
-            ],
-        ],
 
         'reservation' => [
             'label' => 'lang:admin::lang.locations.text_tab_reservation',

--- a/app/admin/models/config/locations_model.php
+++ b/app/admin/models/config/locations_model.php
@@ -324,6 +324,37 @@ $config['form']['tabs'] = [
                 'condition' => 'checked',
             ],
         ],
+        'options[limit_orders]' => [
+            'label' => 'lang:admin::lang.locations.label_limit_orders',
+            'tab' => 'lang:admin::lang.locations.text_tab_data',
+            'default' => 0,
+            'type' => 'switch'
+        ],
+        'options[limit_orders_count]' => [
+            'label' => 'lang:admin::lang.locations.label_limit_orders_count',
+            'tab' => 'lang:admin::lang.locations.text_tab_data',
+            'default' => 50,
+            'type' => 'number',
+            'span' => 'left',
+            'trigger' => [
+                'action' => 'enable',
+                'field' => 'options[limit_orders]',
+                'condition' => 'checked',
+            ],
+        ],
+        'options[limit_orders_interval]' => [
+            'label' => 'lang:admin::lang.locations.label_limit_orders_interval',
+            'tab' => 'lang:admin::lang.locations.text_tab_data',
+            'default' => 30,
+            'type' => 'number',
+            'span' => 'right',
+            'comment' => 'lang:admin::lang.locations.help_limit_orders_interval',
+            'trigger' => [
+                'action' => 'enable',
+                'field' => 'options[limit_orders]',
+                'condition' => 'checked',
+            ],
+        ],
 
         'reservation' => [
             'label' => 'lang:admin::lang.locations.text_tab_reservation',

--- a/app/admin/models/config/locations_model.php
+++ b/app/admin/models/config/locations_model.php
@@ -328,7 +328,7 @@ $config['form']['tabs'] = [
             'label' => 'lang:admin::lang.locations.label_limit_orders',
             'tab' => 'lang:admin::lang.locations.text_tab_data',
             'default' => 0,
-            'type' => 'switch'
+            'type' => 'switch',
         ],
         'options[limit_orders_count]' => [
             'label' => 'lang:admin::lang.locations.label_limit_orders_count',


### PR DESCRIPTION
Here is the beginning of order limitation - the admin settings. It should be pretty straightforward. All the other changes required will come in the extensions.

I haven't included reservation limitation as it occurred to me that could be done by whether the tables are full at a given time slot. If you are happy with that approach I will work on that separately after completing this side of things.



