### PR TITLE
cartItem is not always an object

### DIFF
--- a/app/admin/traits/ManagesOrderItems.php
+++ b/app/admin/traits/ManagesOrderItems.php
@@ -118,6 +118,7 @@ trait ManagesOrderItems
         $this->orderMenuOptionsQuery()->where('order_id', $orderId)->delete();
 
         foreach ($content as $rowId => $cartItem) {
+            $cartItem = is_array($cartItem) ? (object) $cartItem : $cartItem;
             if ($rowId != $cartItem->rowId) continue;
 
             $orderMenuId = $this->orderMenusQuery()->insertGetId([


### PR DESCRIPTION
Convert cartItem when it's an array, for instance when coming from API :
https://github.com/tastyigniter/ti-ext-api/blob/master/apiresources/Orders.php#L56

Also related to this bug: https://github.com/tastyigniter/ti-ext-api/issues/15