### PR TITLE
Switch from SweetAlert to SweetAlert2

### DIFF
--- a/app/admin/assets/package.json
+++ b/app/admin/assets/package.json
@@ -23,6 +23,6 @@
     "select2": "4.0.13",
     "select2-theme-bootstrap4": "0.2.0-beta.2",
     "sortablejs": "^1.10.2",
-    "sweetalert": "^2.1.0"
+    "sweetalert2": "^10.4.0"
   }
 }

--- a/app/admin/assets/webpack.mix.js
+++ b/app/admin/assets/webpack.mix.js
@@ -60,7 +60,7 @@ mix.copyDirectory(
 //         'node_modules/jquery/dist/jquery.min.js',
 //         'node_modules/popper.js/dist/umd/popper.min.js',
 //         'node_modules/bootstrap/dist/js/bootstrap.min.js',
-//         'node_modules/sweetalert/dist/sweetalert.min.js',
+//         'node_modules/sweetalert2/dist/sweetalert2.all.min.js',
 //         '../../system/assets/ui/js/vendor/waterfall.min.js',
 //         '../../system/assets/ui/js/vendor/transition.js',
 //         '../../system/assets/ui/js/app.js',

--- a/app/admin/views/_partials/flash.blade.php
+++ b/app/admin/views/_partials/flash.blade.php
@@ -5,8 +5,8 @@
             data-title="{{ array_get($message, 'title') }}"
             data-text="{!! array_get($message, 'message') !!}"
             data-icon="{{ $message['level'] }}"
-            data-close-on-click-outside="{{ $message['important'] ? 'false' : 'true' }}"
-            data-close-on-esc="{{ $message['important'] ? 'false' : 'true' }}"
+            data-allow-outside-click="{{ $message['important'] ? 'false' : 'true' }}"
+            data-allow-escape-key="{{ $message['important'] ? 'false' : 'true' }}"
         ></div>
     @else
         <div

--- a/app/system/ServiceProvider.php
+++ b/app/system/ServiceProvider.php
@@ -336,7 +336,7 @@ class ServiceProvider extends AppServiceProvider
                 '~/app/admin/assets/node_modules/jquery/dist/jquery.min.js',
                 '~/app/admin/assets/node_modules/popper.js/dist/umd/popper.min.js',
                 '~/app/admin/assets/node_modules/bootstrap/dist/js/bootstrap.min.js',
-                '~/app/admin/assets/node_modules/sweetalert/dist/sweetalert.min.js',
+                '~/app/admin/assets/node_modules/sweetalert2/dist/sweetalert2.all.min.js',
                 '~/app/system/assets/ui/js/vendor/waterfall.min.js',
                 '~/app/system/assets/ui/js/vendor/transition.js',
                 '~/app/system/assets/ui/js/app.js',

--- a/app/system/assets/ui/js/flashmessage.js
+++ b/app/system/assets/ui/js/flashmessage.js
@@ -81,10 +81,10 @@
 
         $('[data-control="flash-overlay"]').each(function (index, element) {
             var $this = $(element),
-                options = $.extend({}, $this.data(), $this.data('closeOnEsc') === true ? {
+                options = $.extend({buttonsStyling: false}, $this.data(), $this.data('allowEscapeKey') === true ? {
                 timer: (index + 1) * 3000
             } : {})
-            swal(options)
+            Swal.fire(options)
         })
     })
 

--- a/app/system/assets/ui/scss/components/_alert.scss
+++ b/app/system/assets/ui/scss/components/_alert.scss
@@ -33,9 +33,9 @@
     margin-bottom: 0;
   }
 }
-.swal-button--confirm {
+.swal2-confirm {
   @extend .btn-primary;
 }
-.swal-button--cancel {
+.swal2-cancel {
   @extend .btn-light;
 }


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/sweetalert2/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

Documentation for SweetAlert2: https://sweetalert2.github.io/

### Reasons to switch:

1. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2020, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

2. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/sweetalert2/sweetalert2.svg)

3. SweetAlert2 is far more popular and battle-tested that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)