### PR TITLE
Fix Instagram CSRF token mismatch

### DIFF
--- a/app/system/assets/ui/js/app.js
+++ b/app/system/assets/ui/js/app.js
@@ -272,6 +272,10 @@ if (window.jQuery.request !== undefined)
 
         $(window).trigger('ajaxBeforeSend', [context])
         $el.trigger('ajaxPromise', [context])
+
+        const token = $('meta[name="csrf-token"]').attr('content');
+        requestOptions.headers["X-CSRF-TOKEN"] = token;
+
         return $.ajax(requestOptions)
             .fail(function (jqXHR, textStatus, errorThrown) {
                 if (!isRedirect) {


### PR DESCRIPTION
**Problem**

When loading the TastyIgniter for the first time via the Instagram app and adding something to the cart, a CSRF token mismatch error would always appear.

The problem would only appear on the first time you load the page. If you refreshed the page, the problem would disappear. 

Despite `$.ajaxPrefilter` adding the CSRF token to the requests, adding it to the request headers manually (see changes in pull request) has fixed the problem and I cannot re-reproduce with my change in place.  Probably needs further investigating and a better solution than this however.

**Notes**
The Instagram app loads web url's into it's own special webview. 

**Tested on**
- iPad Pro
- iOS Instagram App 

**Steps to reproduce** 
- Add site url to Instagram profile so you're able to launch the app. (Clear instagram webview browser cache if you've loaded the page before.)
- Go to profile and click the url.
- Add something to your cart. (CSRF token mismatch error occurs)



