### PR TITLE
Force connector model refresh

### DIFF
--- a/app/admin/classes/BaseFormWidget.php
+++ b/app/admin/classes/BaseFormWidget.php
@@ -126,12 +126,12 @@ class BaseFormWidget extends BaseWidget
         }
 
         $defaultValue = !$this->model->exists
-            ? $this->formField->getDefaultFromData($this->data ?: $this->model)
+            ? $this->formField->getDefaultFromData($this->data ?: $this->model->fresh())
             : null;
 
         if ($value = post($this->formField->getName()))
             return $value;
 
-        return $this->formField->getValueFromData($this->data ?: $this->model, $defaultValue);
+        return $this->formField->getValueFromData($this->data ?: $this->model->fresh(), $defaultValue);
     }
 }

--- a/app/admin/classes/BaseFormWidget.php
+++ b/app/admin/classes/BaseFormWidget.php
@@ -126,12 +126,12 @@ class BaseFormWidget extends BaseWidget
         }
 
         $defaultValue = !$this->model->exists
-            ? $this->formField->getDefaultFromData($this->data ?: $this->model->fresh())
+            ? $this->formField->getDefaultFromData($this->data ?: $this->model)
             : null;
 
         if ($value = post($this->formField->getName()))
             return $value;
 
-        return $this->formField->getValueFromData($this->data ?: $this->model->fresh(), $defaultValue);
+        return $this->formField->getValueFromData($this->data ?: $this->model, $defaultValue);
     }
 }

--- a/app/admin/formwidgets/Connector.php
+++ b/app/admin/formwidgets/Connector.php
@@ -151,6 +151,8 @@ class Connector extends BaseFormWidget
         flash()->success(sprintf(lang('admin::lang.alert_success'), 'Item updated'))->now();
 
         $this->formField->value = null;
+        $this->model->reloadRelations();
+
         $this->prepareVars();
 
         return [

--- a/app/admin/formwidgets/Connector.php
+++ b/app/admin/formwidgets/Connector.php
@@ -150,6 +150,7 @@ class Connector extends BaseFormWidget
 
         flash()->success(sprintf(lang('admin::lang.alert_success'), 'Item updated'))->now();
 
+        $this->formField->value = null;
         $this->prepareVars();
 
         return [


### PR DESCRIPTION
Noticed that connector lists dont refresh on edit (well they do but its always one save behind).

This hack is to show what needs to be done to force a refresh ($model->fresh()) and setting the value to be null. I would probably add a new function to baseformwidget - refreshModel() or something to do both of these steps, but I didnt want to do that in case you had another way.