### PR TITLE
Require location when adding menu option sets. Fixes #689

### DIFF
--- a/app/admin/models/Menu_options_model.php
+++ b/app/admin/models/Menu_options_model.php
@@ -58,6 +58,7 @@ class Menu_options_model extends Model
     public $rules = [
         ['option_name', 'lang:admin::lang.menu_options.label_option_name', 'required|min:2|max:32'],
         ['display_type', 'lang:admin::lang.menu_options.label_display_type', 'required|alpha'],
+        ['locations', 'admin::lang.column_location', 'required'],
         ['locations.*', 'lang:admin::lang.label_location', 'integer'],
     ];
 


### PR DESCRIPTION
Require location to be selected when adding a new menu option set in Menus->Options

Fixes #689 