### PR TITLE
Update media manager CSS to fix dropdown scrolling. 

### DIFF
--- a/app/main/widgets/mediamanager/assets/css/mediamanager.css
+++ b/app/main/widgets/mediamanager/assets/css/mediamanager.css
@@ -172,5 +172,7 @@ Uploader
 Folder Tree
 */
 .folder-tree {
-	min-width: 250px;
+  min-width: 250px;
+  max-height: 460px;
+  overflow: auto;
 }


### PR DESCRIPTION
Updated CSS for media manager so that the folder dropdown will scroll if there are more folder than will fit on the screen.

Closes #700 
