### PR TITLE
Move events to classes

### DIFF
--- a/app/admin/classes/AdminController.php
+++ b/app/admin/classes/AdminController.php
@@ -3,6 +3,7 @@
 namespace Admin\Classes;
 
 use Admin;
+use Admin\Events\Controller\AfterConstructor;
 use Admin\Traits\HasAuthentication;
 use Admin\Traits\ValidatesForm;
 use Admin\Traits\WidgetMaker;
@@ -98,7 +99,7 @@ class AdminController extends BaseController
             $manager->bindToController();
         }
 
-        event(new \Admin\Events\Controller\AfterConstructor($this));
+        event(new AfterConstructor($this));
     }
 
     protected function definePaths()

--- a/app/admin/classes/AdminController.php
+++ b/app/admin/classes/AdminController.php
@@ -98,7 +98,7 @@ class AdminController extends BaseController
             $manager->bindToController();
         }
 
-        $this->fireEvent('controller.afterConstructor', [$this]);
+        \Admin\Events\Controller\AfterConstructor::dispatch($this);
     }
 
     protected function definePaths()

--- a/app/admin/classes/AdminController.php
+++ b/app/admin/classes/AdminController.php
@@ -98,7 +98,7 @@ class AdminController extends BaseController
             $manager->bindToController();
         }
 
-        \Admin\Events\Controller\AfterConstructor::dispatch($this);
+        event(new \Admin\Events\Controller\AfterConstructor($this));
     }
 
     protected function definePaths()

--- a/app/admin/events/controller/AfterConstructor.php
+++ b/app/admin/events/controller/AfterConstructor.php
@@ -2,10 +2,15 @@
 
 namespace Admin\Events\Controller;
 
-use Igniter\Flame\Events\BaseEvent;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use System\Traits\DispatchesLegacyEvent;
 
-class AfterConstructor extends BaseEvent
+class AfterConstructor
 {
+    use Dispatchable, DispatchesLegacyEvent, InteractsWithSockets, SerializesModels;
+
     public $controller;
 
     public function __construct($controller)

--- a/app/admin/events/controller/AfterConstructor.php
+++ b/app/admin/events/controller/AfterConstructor.php
@@ -2,22 +2,16 @@
 
 namespace Admin\Events\Controller;
 
-use Event;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
-use Illuminate\Queue\SerializesModels;
+use Igniter\Flame\Events\BaseEvent;
 
-class AfterConstructor
+class AfterConstructor extends BaseEvent
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
-
     public $controller;
 
     public function __construct($controller)
     {
         $this->controller = $controller;
 
-        // deprecate on next major release
-        Event::fire('controller.afterContructor', [$this->controller]);
+        $this->fireBackwardsCompatibleEvent('controller.afterContructor', [$this->controller]);
     }
 }

--- a/app/admin/events/controller/AfterConstructor.php
+++ b/app/admin/events/controller/AfterConstructor.php
@@ -2,8 +2,14 @@
 
 namespace Admin\Events\Controller;
 
-class AfterConstructor extends Event
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class AfterConstructor
 {
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
     public $controller;
 
     public function __construct($controller)

--- a/app/admin/events/controller/AfterConstructor.php
+++ b/app/admin/events/controller/AfterConstructor.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Admin\Events\Controller;
+
+class AfterConstructor extends Event
+{
+    public $controller;
+
+    public function __construct($controller)
+    {
+        $this->controller = $controller;
+    }
+}

--- a/app/admin/events/controller/AfterConstructor.php
+++ b/app/admin/events/controller/AfterConstructor.php
@@ -2,6 +2,7 @@
 
 namespace Admin\Events\Controller;
 
+use Event;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
@@ -15,5 +16,8 @@ class AfterConstructor
     public function __construct($controller)
     {
         $this->controller = $controller;
+
+        // deprecate on next major release
+        Event::fire('controller.afterContructor', [$this->controller]);
     }
 }

--- a/app/admin/events/controller/FormExtendQuery.php
+++ b/app/admin/events/controller/FormExtendQuery.php
@@ -2,10 +2,15 @@
 
 namespace Admin\Events\Controller;
 
-use Igniter\Flame\Events\BaseEvent;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use System\Traits\DispatchesLegacyEvent;
 
-class FormExtendQuery extends BaseEvent
+class FormExtendQuery
 {
+    use Dispatchable, DispatchesLegacyEvent, InteractsWithSockets, SerializesModels;
+
     public $query;
 
     public function __construct($query)

--- a/app/admin/events/controller/FormExtendQuery.php
+++ b/app/admin/events/controller/FormExtendQuery.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Admin\Events\Controller;
+
+class FormExtendQuery extends Event
+{
+    public $query;
+
+    public function __construct($query)
+    {
+        $this->query = $query;
+    }
+}

--- a/app/admin/events/controller/FormExtendQuery.php
+++ b/app/admin/events/controller/FormExtendQuery.php
@@ -2,22 +2,16 @@
 
 namespace Admin\Events\Controller;
 
-use Event;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
-use Illuminate\Queue\SerializesModels;
+use Igniter\Flame\Events\BaseEvent;
 
-class FormExtendQuery
+class FormExtendQuery extends BaseEvent
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
-
     public $query;
 
     public function __construct($query)
     {
         $this->query = $query;
 
-        // deprecate on next major release
-        Event::fire('controller.form.extendQuery', [$this->query]);
+        $this->fireBackwardsCompatibleEvent('controller.form.extendQuery', [$this->query]);
     }
 }

--- a/app/admin/events/controller/FormExtendQuery.php
+++ b/app/admin/events/controller/FormExtendQuery.php
@@ -2,8 +2,14 @@
 
 namespace Admin\Events\Controller;
 
-class FormExtendQuery extends Event
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class FormExtendQuery
 {
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
     public $query;
 
     public function __construct($query)

--- a/app/admin/events/controller/FormExtendQuery.php
+++ b/app/admin/events/controller/FormExtendQuery.php
@@ -2,6 +2,7 @@
 
 namespace Admin\Events\Controller;
 
+use Event;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
@@ -15,5 +16,8 @@ class FormExtendQuery
     public function __construct($query)
     {
         $this->query = $query;
+
+        // deprecate on next major release
+        Event::fire('controller.form.extendQuery', [$this->query]);
     }
 }

--- a/app/admin/events/widgets/calendar/UpdateEvent.php
+++ b/app/admin/events/widgets/calendar/UpdateEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Admin\Events\Widgets\Calendar;
+
+use Event;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class UpdateEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $eventId;
+    public $startAt;
+    public $endAt;
+
+    public function __construct($eventId, $startAt, $endAt)
+    {
+        $this->eventId = $eventId;
+        $this->startAt = $startAt;
+        $this->endAt = $endAt;
+
+        // deprecate on next major release
+        Event::fire('calendar.updateEvent', [$eventId, $startAt, $endAt]);
+
+    }
+}

--- a/app/admin/events/widgets/calendar/UpdateEvent.php
+++ b/app/admin/events/widgets/calendar/UpdateEvent.php
@@ -2,10 +2,15 @@
 
 namespace Admin\Events\Widgets\Calendar;
 
-use Igniter\Flame\Events\BaseEvent;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use System\Traits\DispatchesLegacyEvent;
 
-class UpdateEvent extends BaseEvent
+class UpdateEvent
 {
+    use Dispatchable, DispatchesLegacyEvent, InteractsWithSockets, SerializesModels;
+
     public $eventId;
     public $startAt;
     public $endAt;

--- a/app/admin/events/widgets/calendar/UpdateEvent.php
+++ b/app/admin/events/widgets/calendar/UpdateEvent.php
@@ -2,15 +2,10 @@
 
 namespace Admin\Events\Widgets\Calendar;
 
-use Event;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
-use Illuminate\Queue\SerializesModels;
+use Igniter\Flame\Events\BaseEvent;
 
-class UpdateEvent
+class UpdateEvent extends BaseEvent
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
-
     public $eventId;
     public $startAt;
     public $endAt;
@@ -21,8 +16,6 @@ class UpdateEvent
         $this->startAt = $startAt;
         $this->endAt = $endAt;
 
-        // deprecate on next major release
-        Event::fire('calendar.updateEvent', [$eventId, $startAt, $endAt]);
-
+        $this->fireBackwardsCompatibleEvent('calendar.updateEvent', [$eventId, $startAt, $endAt]);
     }
 }

--- a/app/admin/traits/FormExtendable.php
+++ b/app/admin/traits/FormExtendable.php
@@ -2,6 +2,7 @@
 
 namespace Admin\Traits;
 
+use Admin\Events\Controller\FormExtendQuery;
 use Event;
 use Exception;
 
@@ -83,7 +84,7 @@ trait FormExtendable
 
         // Prepare query and find model record
         $query = $model->newQuery();
-        event(new \Admin\Events\Controller\FormExtendQuery($query));
+        event(new FormExtendQuery($query));
         $this->controller->formExtendQuery($query);
 
         $result = $query->find($recordId);

--- a/app/admin/traits/FormExtendable.php
+++ b/app/admin/traits/FormExtendable.php
@@ -83,7 +83,7 @@ trait FormExtendable
 
         // Prepare query and find model record
         $query = $model->newQuery();
-        \Admin\Events\Controller\FormExtendQuery::dispatch($query);
+        event(new \Admin\Events\Controller\FormExtendQuery($query));
         $this->controller->formExtendQuery($query);
 
         $result = $query->find($recordId);

--- a/app/admin/traits/FormExtendable.php
+++ b/app/admin/traits/FormExtendable.php
@@ -83,7 +83,7 @@ trait FormExtendable
 
         // Prepare query and find model record
         $query = $model->newQuery();
-        $this->controller->fireEvent('controller.form.extendQuery', [$query]);
+        \Admin\Events\Controller\FormExtendQuery::dispatch($query);
         $this->controller->formExtendQuery($query);
 
         $result = $query->find($recordId);

--- a/app/admin/widgets/Calendar.php
+++ b/app/admin/widgets/Calendar.php
@@ -3,6 +3,7 @@
 namespace Admin\Widgets;
 
 use Admin\Classes\BaseWidget;
+use Admin\Events\Widgets\Calendar\UpdateEvent;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Support\Facades\Request;
@@ -102,7 +103,7 @@ class Calendar extends BaseWidget
         $startAt = Request::get('start');
         $endAt = Request::get('end');
 
-        event(new \Admin\Events\Widgets\Calendar\UpdateEvent($eventId, $startAt, $endAt));
+        event(new UpdateEvent($eventId, $startAt, $endAt));
     }
 
     public function renderPopoverPartial()

--- a/app/admin/widgets/Calendar.php
+++ b/app/admin/widgets/Calendar.php
@@ -102,7 +102,7 @@ class Calendar extends BaseWidget
         $startAt = Request::get('start');
         $endAt = Request::get('end');
 
-        $this->fireEvent('calendar.updateEvent', [$eventId, $startAt, $endAt]);
+        event(new \Admin\Events\Widgets\Calendar\UpdateEvent($eventId, $startAt, $endAt));
     }
 
     public function renderPopoverPartial()

--- a/app/main/classes/MainController.php
+++ b/app/main/classes/MainController.php
@@ -18,6 +18,7 @@ use Igniter\Flame\Traits\EventEmitter;
 use Illuminate\Http\RedirectResponse;
 use Lang;
 use Main\Components\BlankComponent;
+use Main\Events\Controller\AfterConstructor;
 use Main\Template\ComponentPartial;
 use Main\Template\Content;
 use Main\Template\Extension\BladeExtension as MainBladeExtension;
@@ -158,7 +159,7 @@ class MainController extends BaseController
 
         $this->initTemplateEnvironment();
 
-        event(new \Main\Events\Controller\AfterConstructor($this));
+        event(new AfterConstructor($this));
 
         self::$controller = $this;
     }

--- a/app/main/classes/MainController.php
+++ b/app/main/classes/MainController.php
@@ -158,7 +158,7 @@ class MainController extends BaseController
 
         $this->initTemplateEnvironment();
 
-        $this->fireEvent('controller.afterConstructor', [$this]);
+        event(new \Main\Events\Controller\AfterConstructor($this));
 
         self::$controller = $this;
     }

--- a/app/main/events/controller/AfterConstructor.php
+++ b/app/main/events/controller/AfterConstructor.php
@@ -2,22 +2,16 @@
 
 namespace Main\Events\Controller;
 
-use Event;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
-use Illuminate\Queue\SerializesModels;
+use Igniter\Flame\Events\BaseEvent;
 
-class AfterConstructor
+class AfterConstructor extends BaseEvent
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
-
     public $controller;
 
     public function __construct($controller)
     {
         $this->controller = $controller;
 
-        // deprecate on next major release
-        Event::fire('controller.afterContructor', [$this->controller]);
+        $this->fireBackwardsCompatibleEvent('controller.afterContructor', [$this->controller]);
     }
 }

--- a/app/main/events/controller/AfterConstructor.php
+++ b/app/main/events/controller/AfterConstructor.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Main\Events\Controller;
+
+use Event;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class AfterConstructor
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $controller;
+
+    public function __construct($controller)
+    {
+        $this->controller = $controller;
+
+        // deprecate on next major release
+        Event::fire('controller.afterContructor', [$this->controller]);
+    }
+}

--- a/app/main/events/controller/AfterConstructor.php
+++ b/app/main/events/controller/AfterConstructor.php
@@ -2,10 +2,15 @@
 
 namespace Main\Events\Controller;
 
-use Igniter\Flame\Events\BaseEvent;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use System\Traits\DispatchesLegacyEvent;
 
-class AfterConstructor extends BaseEvent
+class AfterConstructor
 {
+    use Dispatchable, DispatchesLegacyEvent, InteractsWithSockets, SerializesModels;
+
     public $controller;
 
     public function __construct($controller)

--- a/app/main/events/template/FillViewBagArray.php
+++ b/app/main/events/template/FillViewBagArray.php
@@ -9,7 +9,7 @@ use System\Traits\DispatchesLegacyEvent;
 
 class FillViewBagArray
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    use Dispatchable, DispatchesLegacyEvent, InteractsWithSockets, SerializesModels;
 
     public function __construct()
     {

--- a/app/main/events/template/FillViewBagArray.php
+++ b/app/main/events/template/FillViewBagArray.php
@@ -2,18 +2,14 @@
 
 namespace Main\Events\Template;
 
-use Event;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
-use Illuminate\Queue\SerializesModels;
+use Igniter\Flame\Events\BaseEvent;
 
-class FillViewBagArray
+class FillViewBagArray extends BaseEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     public function __construct()
     {
-        // deprecate on next major release
-        Event::fire('templateModel.fillViewBagArray');
+        $this->fireBackwardsCompatibleEvent('templateModel.fillViewBagArray');
     }
 }

--- a/app/main/events/template/FillViewBagArray.php
+++ b/app/main/events/template/FillViewBagArray.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Main\Events\Template;
+
+use Event;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class FillViewBagArray
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct()
+    {
+        // deprecate on next major release
+        Event::fire('templateModel.fillViewBagArray');
+    }
+}

--- a/app/main/events/template/FillViewBagArray.php
+++ b/app/main/events/template/FillViewBagArray.php
@@ -2,9 +2,12 @@
 
 namespace Main\Events\Template;
 
-use Igniter\Flame\Events\BaseEvent;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use System\Traits\DispatchesLegacyEvent;
 
-class FillViewBagArray extends BaseEvent
+class FillViewBagArray
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/app/main/template/concerns/HasViewBag.php
+++ b/app/main/template/concerns/HasViewBag.php
@@ -3,6 +3,7 @@
 namespace Main\Template\Concerns;
 
 use Main\Components\ViewBag;
+use Main\Events\Template\FillViewBagArray;
 
 trait HasViewBag
 {
@@ -70,6 +71,6 @@ trait HasViewBag
             $this->viewBag[$name] = $value;
         }
 
-        event(new \Main\Events\Template\FillViewBagArray());
+        event(new FillViewBagArray());
     }
 }

--- a/app/main/template/concerns/HasViewBag.php
+++ b/app/main/template/concerns/HasViewBag.php
@@ -70,6 +70,6 @@ trait HasViewBag
             $this->viewBag[$name] = $value;
         }
 
-        $this->fireEvent('templateModel.fillViewBagArray');
+        event(new \Main\Events\Template\FillViewBagArray());
     }
 }

--- a/app/system/classes/BaseController.php
+++ b/app/system/classes/BaseController.php
@@ -66,7 +66,7 @@ class BaseController extends Extendable
 
         $this->extendableConstruct();
 
-        $this->fireEvent('controller.beforeConstructor', [$this]);
+        event(new \System\Events\Controller\BeforeConstructor($this));
     }
 
     public function getClass()

--- a/app/system/classes/BaseController.php
+++ b/app/system/classes/BaseController.php
@@ -4,6 +4,7 @@ namespace System\Classes;
 
 use Igniter\Flame\Support\Extendable;
 use Igniter\Flame\Traits\EventEmitter;
+use System\Events\Controller\BeforeConstructor;
 
 /**
  * Base Controller Class
@@ -66,7 +67,7 @@ class BaseController extends Extendable
 
         $this->extendableConstruct();
 
-        event(new \System\Events\Controller\BeforeConstructor($this));
+        event(new BeforeConstructor($this));
     }
 
     public function getClass()

--- a/app/system/events/controller/BeforeConstructor.php
+++ b/app/system/events/controller/BeforeConstructor.php
@@ -2,7 +2,6 @@
 
 namespace System\Events\Controller;
 
-use Igniter\Flame\Events\BaseEvent;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;

--- a/app/system/events/controller/BeforeConstructor.php
+++ b/app/system/events/controller/BeforeConstructor.php
@@ -3,9 +3,15 @@
 namespace System\Events\Controller;
 
 use Igniter\Flame\Events\BaseEvent;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use System\Traits\DispatchesLegacyEvent;
 
-class BeforeConstructor extends BaseEvent
+class BeforeConstructor
 {
+    use Dispatchable, DispatchesLegacyEvent, InteractsWithSockets, SerializesModels;
+
     public $controller;
 
     public function __construct($controller)

--- a/app/system/events/controller/BeforeConstructor.php
+++ b/app/system/events/controller/BeforeConstructor.php
@@ -2,22 +2,16 @@
 
 namespace System\Events\Controller;
 
-use Event;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
-use Illuminate\Queue\SerializesModels;
+use Igniter\Flame\Events\BaseEvent;
 
-class BeforeConstructor
+class BeforeConstructor extends BaseEvent
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
-
     public $controller;
 
     public function __construct($controller)
     {
         $this->controller = $controller;
 
-        // deprecate on next major release
-        Event::fire('controller.beforeConstructor', [$this->controller]);
+        $this->fireBackwardsCompatibleEvent('controller.beforeConstructor', [$this->controller]);
     }
 }

--- a/app/system/events/controller/BeforeConstructor.php
+++ b/app/system/events/controller/BeforeConstructor.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace System\Events\Controller;
+
+use Event;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class BeforeConstructor
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $controller;
+
+    public function __construct($controller)
+    {
+        $this->controller = $controller;
+
+        // deprecate on next major release
+        Event::fire('controller.beforeConstructor', [$this->controller]);
+    }
+}

--- a/app/system/traits/DispatchesLegacyEvent.php
+++ b/app/system/traits/DispatchesLegacyEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace System\Traits;
+
+use Event;
+
+trait DispatchesLegacyEvent
+{
+    public function fireBackwardsCompatibleEvent($name, $params = null)
+    {
+        Event::fire($name, $params);
+    }
+}


### PR DESCRIPTION
Move away from defining event names in favour of event classes.

To do:

- [ ] Migrate all admin, system and main events to classes
- [ ] Work out how to support events subscribed by name eg (controller.afterConstructor)
- [ ] Apply to core/official extensions

For discussion

- Do we move away from looking for return values from events, instead we just allow them to modify param values? (This seems like the 'laravel way')
- Should we enable EventServiceProvider (https://laravel.com/docs/8.x/events#registering-event-subscribers) and use it for any events we subscribe to internally  