### PR TITLE
Fixes case when file doesnt actually exist (eg translation js)

### DIFF
--- a/app/system/traits/CombinesAssets.php
+++ b/app/system/traits/CombinesAssets.php
@@ -207,6 +207,9 @@ trait CombinesAssets
             if (!file_exists($path))
                 $path = File::symbolizePath($path, null) ?? $path;
 
+            if (!file_exists($path))
+                continue;
+
             $asset = starts_with($path, ['//', 'http://', 'https://'])
                 ? new HttpAsset($path, $filters)
                 : new FileAsset($path, $filters, public_path());


### PR DESCRIPTION
For context: https://discord.com/channels/486734519798333440/534045257730359309/908083845474164767