### PR TITLE
Allow for Command-line unattended installation

### DIFF
--- a/app/system/ServiceProvider.php
+++ b/app/system/ServiceProvider.php
@@ -186,6 +186,7 @@ class ServiceProvider extends AppServiceProvider
                 'igniter.up' => Console\Commands\IgniterUp::class,
                 'igniter.down' => Console\Commands\IgniterDown::class,
                 'igniter.install' => Console\Commands\IgniterInstall::class,
+                'igniter.install-unattended' => Console\Commands\IgniterInstallUnattended::class,
                 'igniter.update' => Console\Commands\IgniterUpdate::class,
                 'igniter.passwd' => Console\Commands\IgniterPasswd::class,
                 'extension.install' => Console\Commands\ExtensionInstall::class,

--- a/app/system/console/commands/IgniterInstall.php
+++ b/app/system/console/commands/IgniterInstall.php
@@ -160,7 +160,7 @@ class IgniterInstall extends Command
             return $answer;
         });
 
-        $username = $this->output->ask('Admin Username', 'admin', function ($answer) {
+        $username = $this->output->ask('Admin Username', DatabaseSeeder::$staffUsername, function ($answer) {
             if (Users_model::whereUsername($answer)->first()) {
                 throw new \RuntimeException('An administrator with that username already exists, please choose a different username.');
             }
@@ -168,7 +168,7 @@ class IgniterInstall extends Command
             return $answer;
         });
 
-        $password = $this->output->ask('Admin Password', '123456', function ($answer) {
+        $password = $this->output->ask('Admin Password', DatabaseSeeder::$staffPassword, function ($answer) {
             if (!is_string($answer) || strlen($answer) < 6) {
                 throw new \RuntimeException('Please specify the administrator password, at least 6 characters');
             }

--- a/app/system/console/commands/IgniterInstallUnattended.php
+++ b/app/system/console/commands/IgniterInstallUnattended.php
@@ -139,7 +139,8 @@ class IgniterInstallUnattended extends Command
      */
     public function handle()
     {
-        $this->alert('INSTALLATION');
+        $this->newLine();
+        $this->alert('Checking Options');
 
         if (App::hasDatabase() && !$this->option('force')) {
             $this->error('Application appears to be installed already. Please use -f|--force to override this.');
@@ -147,9 +148,9 @@ class IgniterInstallUnattended extends Command
             return;
         }
 
-        $this->line('Enter a new value, or press ENTER for the default');
-
         $this->setSeederProperties();
+
+        $this->alert('Installing');
 
         $this->rewriteEnvFile();
 
@@ -162,7 +163,8 @@ class IgniterInstallUnattended extends Command
         $this->moveExampleFile('htaccess', null, 'backup');
         $this->moveExampleFile('htaccess', 'example', null);
 
-        $this->alert('INSTALLATION COMPLETE');
+        $this->newLine();
+        $this->alert('Installation Complete');
     }
 
     protected function rewriteEnvFile()
@@ -207,22 +209,48 @@ class IgniterInstallUnattended extends Command
 
     protected function setSeederProperties()
     {
-        $this->dbConfig['host']     = $this->option('mysql-host');
-        $this->dbConfig['port']     = $this->option('mysql-port');
-        $this->dbConfig['database'] = $this->option('mysql-database');
-        $this->dbConfig['username'] = $this->option('mysql-username');
-        $this->dbConfig['password'] = $this->option('mysql-password');
-        $this->dbConfig['prefix']   = $this->option('mysql-table-prefix');
-
-        DatabaseSeeder::$siteName = $this->option('site-name');
-        DatabaseSeeder::$siteUrl  = $this->option('site-url');
-
-        DatabaseSeeder::$siteEmail     = $this->option('admin-email');
-        DatabaseSeeder::$staffName     = $this->option('admin-name');
-        DatabaseSeeder::$staffUsername = $this->option('admin-username');
-        DatabaseSeeder::$staffPassword = $this->option('admin-password');
+        $this->info('Passed force flag: '.($this->option('force') ? 'Yes' : 'No'));
 
         DatabaseSeeder::$seedDemo = $this->option('with-demo-data');
+        $this->info('Passed demo seed data flag: '.(DatabaseSeeder::$seedDemo ? 'Yes' : 'No'));
+
+        DatabaseSeeder::$siteName = $this->option('site-name');
+        $this->info('Passed site name: '.DatabaseSeeder::$siteName);
+
+        DatabaseSeeder::$siteUrl = $this->option('site-url');
+        $this->info('Passed site URL: '.DatabaseSeeder::$siteUrl);
+
+        DatabaseSeeder::$siteEmail = $this->option('admin-email');
+        $this->info('Passed admin email: '.DatabaseSeeder::$siteEmail);
+
+        DatabaseSeeder::$staffName = $this->option('admin-name');
+        $this->info('Passed admin name: '.DatabaseSeeder::$staffName);
+
+        DatabaseSeeder::$staffUsername = $this->option('admin-username');
+        $this->info('Passed admin username: '.DatabaseSeeder::$staffUsername);
+
+        DatabaseSeeder::$staffPassword = $this->option('admin-password');
+        $this->info('Passed admin password: *');
+
+        $this->dbConfig['host'] = $this->option('mysql-host');
+        $this->info('Passed MySQL host: '.$this->dbConfig['host']);
+
+        $this->dbConfig['port'] = $this->option('mysql-port');
+        $this->info('Passed MySQL port: '.$this->dbConfig['port']);
+
+        $this->dbConfig['database'] = $this->option('mysql-database');
+        $this->info('Passed MySQL database: '.$this->dbConfig['database']);
+
+        $this->dbConfig['username'] = $this->option('mysql-username');
+        $this->info('Passed MySQL username: '.$this->dbConfig['username']);
+
+        $this->dbConfig['password'] = $this->option('mysql-password');
+        $this->info('Passed MySQL password: *');
+
+        $this->dbConfig['prefix'] = $this->option('mysql-table-prefix');
+        $this->info('Passed MySQL prefix: '.$this->dbConfig['prefix']);
+
+        $this->newLine();
     }
 
     protected function createSuperUser()

--- a/app/system/console/commands/IgniterInstallUnattended.php
+++ b/app/system/console/commands/IgniterInstallUnattended.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace System\Console\Commands;
+
+use Admin\Facades\AdminAuth;
+use Admin\Models\Customer_groups_model;
+use Admin\Models\Locations_model;
+use Admin\Models\Staff_groups_model;
+use Admin\Models\Staff_roles_model;
+use Admin\Models\Staffs_model;
+use Admin\Models\Users_model;
+use Igniter\Flame\Support\ConfigRewrite;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\Console\Input\InputOption;
+use System\Classes\UpdateManager;
+use System\Database\Seeds\DatabaseSeeder;
+use System\Models\Languages_model;
+
+/**
+ * Console command to install TastyIgniter in an unattended fashion.
+ * This sets up TastyIgniter for the first time. It will run through setup using the provided values and then
+ * perform a database migration.
+ */
+class IgniterInstallUnattended extends Command
+{
+    /**
+     * The console command name.
+     */
+    protected $name = 'igniter:install-unattended';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Set up TastyIgniter for the first time unattended.';
+
+    /**
+     * Interface for updating local app config entries.
+     */
+    protected ConfigRewrite $configRewrite;
+
+    /**
+     * Temp store for DB config defined during setup.
+     */
+    protected array $dbConfig = [];
+
+    /**
+     * Create a new command instance.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->configRewrite = new ConfigRewrite();
+    }
+
+    /**
+     * Get the console command options. This would normally be in the command signature directly, but due to the config
+     * load requirement, that cannot be done within the constant delcaration of the command signature itself in the
+     * new preferred syntax.
+     */
+    protected function getOptions()
+    {
+        $dbName = Config::get('database.default');
+
+        return [
+            // Force override flag
+            [
+                'force', null, InputOption::VALUE_NONE,
+                'Force install over an existing TastyIgniter database',
+            ],
+
+            // Install demo data flag
+            [
+                'with-demo-data', null, InputOption::VALUE_NONE,
+                'Install TastyIgniter with demo data',
+            ],
+
+            // Site Configuration options
+            [
+                'site-name', null, InputOption::VALUE_REQUIRED,
+                'Site Name', DatabaseSeeder::$siteName,
+            ],
+            [
+                'site-url', null, InputOption::VALUE_REQUIRED,
+                'Site URL', Config::get('app.url'),
+            ],
+
+            // Admin User Configuration options
+            [
+                'admin-email', null, InputOption::VALUE_REQUIRED,
+                'Admin Email', DatabaseSeeder::$siteEmail,
+            ],
+            [
+                'admin-name', null, InputOption::VALUE_REQUIRED,
+                'Admin Name', DatabaseSeeder::$staffName,
+            ],
+            [
+                'admin-username', null, InputOption::VALUE_REQUIRED,
+                'Admin Username', DatabaseSeeder::$staffUsername,
+            ],
+            [
+                'admin-password', null, InputOption::VALUE_REQUIRED,
+                'Admin Password', DatabaseSeeder::$staffPassword,
+            ],
+
+            // MySQL Configuration options
+            [
+                'mysql-host', null, InputOption::VALUE_REQUIRED,
+                'MySQL hostname for the primary DB', Config::get("database.connections.${dbName}.host"),
+            ],
+            [
+                'mysql-port', null, InputOption::VALUE_REQUIRED,
+                'MySQL port for the primary DB', (Config::get("database.connections.${dbName}.port") ?: false),
+            ],
+            [
+                'mysql-database', null, InputOption::VALUE_REQUIRED,
+                'MySQL database name for the primary DB', Config::get("database.connections.${dbName}.database"),
+            ],
+            [
+                'mysql-username', null, InputOption::VALUE_REQUIRED,
+                'MySQL username for the primary DB', Config::get("database.connections.${dbName}.username"),
+            ],
+            [
+                'mysql-password', null, InputOption::VALUE_REQUIRED,
+                'MySQL password for the primary DB', (Config::get("database.connections.${dbName}.password") ?: false),
+            ],
+            [
+                'mysql-table-prefix', null, InputOption::VALUE_REQUIRED,
+                'MySQL password for the primary DB', (Config::get("database.connections.${dbName}.prefix") ?: false),
+            ],
+        ];
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->alert('INSTALLATION');
+
+        if (App::hasDatabase() && !$this->option('force')) {
+            $this->error('Application appears to be installed already. Please use -f|--force to override this.');
+
+            return;
+        }
+
+        $this->line('Enter a new value, or press ENTER for the default');
+
+        $this->setSeederProperties();
+
+        $this->rewriteEnvFile();
+
+        $this->migrateDatabase();
+
+        $this->createSuperUser();
+
+        $this->addSystemValues();
+
+        $this->moveExampleFile('htaccess', null, 'backup');
+        $this->moveExampleFile('htaccess', 'example', null);
+
+        $this->alert('INSTALLATION COMPLETE');
+    }
+
+    protected function rewriteEnvFile()
+    {
+        if (file_exists(base_path().'/.env') && !$this->confirm('Rewrite environment file?', false)) {
+            return;
+        }
+
+        $this->moveExampleFile('env', null, 'backup');
+        $this->copyExampleFile('env', 'example', null);
+
+        $this->replaceInEnv('APP_KEY=', 'APP_KEY='.$this->generateEncryptionKey());
+
+        $this->replaceInEnv('APP_NAME=', 'APP_NAME="'.DatabaseSeeder::$siteName.'"');
+        $this->replaceInEnv('APP_URL=', 'APP_URL='.DatabaseSeeder::$siteUrl);
+
+        $name = Config::get('database.default');
+
+        foreach ($this->dbConfig as $key => $value) {
+            Config::set("database.connections.$name.".strtolower($key), $value);
+
+            if ($key === 'password') {
+                $value = '"'.$value.'"';
+            }
+
+            $this->replaceInEnv('DB_'.strtoupper($key).'=', 'DB_'.strtoupper($key).'='.$value);
+        }
+    }
+
+    protected function migrateDatabase()
+    {
+        $this->line('Migrating application and extensions...');
+
+        DB::purge();
+
+        $manager = UpdateManager::instance()->setLogsOutput($this->output);
+
+        $manager->update();
+
+        $this->line('Done. Migrating application and extensions...');
+    }
+
+    protected function setSeederProperties()
+    {
+        $this->dbConfig['host']     = $this->option('mysql-host');
+        $this->dbConfig['port']     = $this->option('mysql-port');
+        $this->dbConfig['database'] = $this->option('mysql-database');
+        $this->dbConfig['username'] = $this->option('mysql-username');
+        $this->dbConfig['password'] = $this->option('mysql-password');
+        $this->dbConfig['prefix']   = $this->option('mysql-table-prefix');
+
+        DatabaseSeeder::$siteName = $this->option('site-name');
+        DatabaseSeeder::$siteUrl  = $this->option('site-url');
+
+        DatabaseSeeder::$siteEmail     = $this->option('admin-email');
+        DatabaseSeeder::$staffName     = $this->option('admin-name');
+        DatabaseSeeder::$staffUsername = $this->option('admin-username');
+        DatabaseSeeder::$staffPassword = $this->option('admin-password');
+
+        DatabaseSeeder::$seedDemo = $this->option('with-demo-data');
+    }
+
+    protected function createSuperUser()
+    {
+        if (Staffs_model::whereStaffEmail(DatabaseSeeder::$siteEmail)->first()) {
+            throw new \RuntimeException('An administrator with that email already exists, please choose a different email.');
+        }
+
+        if (Users_model::whereUsername(DatabaseSeeder::$staffUsername)->first()) {
+            throw new \RuntimeException('An administrator with that username already exists, please choose a different username.');
+        }
+
+        if (!is_string(DatabaseSeeder::$staffPassword) || strlen(DatabaseSeeder::$staffPassword) < 6) {
+            throw new \RuntimeException('Please specify the administrator password, at least 6 characters');
+        }
+
+        $user = AdminAuth::register([
+            'staff_email'   => DatabaseSeeder::$siteEmail,
+            'staff_name'    => DatabaseSeeder::$staffName,
+            'language_id'   => Languages_model::first()->language_id,
+            'staff_role_id' => Staff_roles_model::first()->staff_role_id,
+            'staff_status'  => true,
+            'username'      => DatabaseSeeder::$staffUsername,
+            'password'      => DatabaseSeeder::$staffPassword,
+            'super_user'    => true,
+            'groups'        => [Staff_groups_model::first()->staff_group_id],
+            'locations'     => [Locations_model::first()->location_id],
+        ]);
+
+        $this->line('Admin user '.$user->username.' created!');
+    }
+
+    protected function addSystemValues()
+    {
+        params()->flushCache();
+
+        params()->set([
+            'ti_setup'            => 'installed',
+            'default_location_id' => Locations_model::first()->location_id,
+        ]);
+
+        params()->save();
+
+        setting()->flushCache();
+        setting()->set('site_name', DatabaseSeeder::$siteName);
+        setting()->set('site_email', DatabaseSeeder::$siteEmail);
+        setting()->set('sender_name', DatabaseSeeder::$siteName);
+        setting()->set('sender_email', DatabaseSeeder::$siteEmail);
+        setting()->set('customer_group_id', Customer_groups_model::first()->customer_group_id);
+        setting()->save();
+
+        // These parameters are no longer in use
+        params()->forget('main_address');
+
+        UpdateManager::instance()->setCoreVersion();
+    }
+
+    protected function writeToConfig($file, $values)
+    {
+        $configFile = $this->getConfigFile($file);
+
+        foreach ($values as $key => $value) {
+            Config::set($file.'.'.$key, $value);
+        }
+
+        $this->configRewrite->toFile($configFile, $values);
+    }
+
+    protected function getConfigFile($name = 'app')
+    {
+        $env  = $this->option('env') ? $this->option('env').'/' : '';
+        $path = $this->laravel['path.config']."/{$env}{$name}.php";
+
+        return $path;
+    }
+
+    protected function generateEncryptionKey()
+    {
+        return 'base64:'.base64_encode(random_bytes(32));
+    }
+
+    protected function moveExampleFile($name, $old, $new)
+    {
+        // /$old.$name => /$new.$name
+        if (file_exists(base_path().'/'.$old.'.'.$name)) {
+            rename(base_path().'/'.$old.'.'.$name, base_path().'/'.$new.'.'.$name);
+        }
+    }
+
+    protected function copyExampleFile($name, $old, $new)
+    {
+        // /$old.$name => /$new.$name
+        if (file_exists(base_path().'/'.$old.'.'.$name)) {
+            if (file_exists(base_path().'/'.$new.'.'.$name)) {
+                unlink(base_path().'/'.$new.'.'.$name);
+            }
+
+            copy(base_path().'/'.$old.'.'.$name, base_path().'/'.$new.'.'.$name);
+        }
+    }
+
+    protected function replaceInEnv(string $search, string $replace)
+    {
+        $file = base_path().'/.env';
+
+        file_put_contents(
+            $file,
+            preg_replace('/^'.$search.'(.*)$/m', $replace, file_get_contents($file))
+        );
+
+        putenv($replace);
+    }
+}

--- a/app/system/console/commands/IgniterInstallUnattended.php
+++ b/app/system/console/commands/IgniterInstallUnattended.php
@@ -321,7 +321,8 @@ class IgniterInstallUnattended extends Command
 
     protected function getConfigFile($name = 'app')
     {
-        $env  = $this->option('env') ? $this->option('env').'/' : '';
+        $env = $this->option('env') ? $this->option('env').'/' : '';
+
         $path = $this->laravel['path.config']."/{$env}{$name}.php";
 
         return $path;

--- a/app/system/database/seeds/DatabaseSeeder.php
+++ b/app/system/database/seeds/DatabaseSeeder.php
@@ -14,10 +14,15 @@ class DatabaseSeeder extends Seeder
 
     public static $staffName = 'Chef Admin';
 
-    public static $seedDemo = TRUE;
+    public static $staffUsername = 'admin';
+
+    public static $staffPassword = '123456';
+
+    public static $seedDemo = true;
 
     /**
      * Run the database seeds.
+     *
      * @return void
      */
     public function run()


### PR DESCRIPTION
## The Brief

One of the key things that I've struggled with when Docker'ising TastyIgniter is that the installation requires input from the maintainer during setup to input the required options.

## The Change

This adds another installation script `igniter:install-unattended` that mirrors the normal CLI installer, but takes all the required options upfront as CLI options.

This is an example of the new unattended installation command:

```bash
php artisan igniter:install-unattended \
    --force \                             # Force install over an existing database
    --with-demo-data \                    # Install the application with demo data
    --site-name="TastyIgniter" \          # Site Name [default: "TastyIgniter"]
    --site-url="http://localhost/" \      # Site URL [default: "http://localhost/"]
    --admin-email="admin@domain.tld" \    # Admin Email [default: "admin@domain.tld"]
    --admin-name="Chef Admin" \           # Admin Name [default: "Chef Admin"]
    --admin-username="admin" \            # Admin Username [default: "admin"]
    --admin-password="123456" \           # Admin Password [default: "123456"]
    --mysql-host="127.0.0.1" \            # MySQL hostname for the primary DB [default: "127.0.0.1"]
    --mysql-port="3306" \                 # MySQL port for the primary DB [default: "3306"]
    --mysql-database="forge" \            # MySQL database name for the primary DB [default: "forge"]
    --mysql-username="forge" \            # MySQL username for the primary DB [default: "forge"]
    --mysql-password="password" \         # MySQL password for the primary DB [default: false]
    --mysql-table-prefix="ti_"            # MySQL password for the primary DB [default: "ti_"]
```

This results in the following example output from a testing run I did of the above command as part of a Docker installation:

```bash
****************************
*     Checking Options     *
****************************

Passed force flag: No
Passed demo seed data flag: Yes
Passed site name: TastyIgniter
Passed site URL: http://localhost/
Passed admin email: admin@domain.tld
Passed admin name: Chef Admin
Passed admin username: admin
Passed admin password: *
Passed MySQL host: ti-docker-testing-database
Passed MySQL port: 3306
Passed MySQL database: tasty
Passed MySQL username: tasty
Passed MySQL password: *
Passed MySQL prefix: ti_

**********************
*     Installing     *
**********************

Migrating application and extensions...
Migration table created
Migrating: 2015_03_25_000001_create_tables
Migrated:  2015_03_25_000001_create_tables (1,010.49ms)
Migrating: 2016_11_29_000300_optimize_tables_columns
Migrated:  2016_11_29_000300_optimize_tables_columns (1,394.33ms)
Migrating: 2017_04_13_000300_modify_columns_on_users_and_customers_tables
Migrated:  2017_04_13_000300_modify_columns_on_users_and_customers_tables (133.77ms)
Migrating: 2017_05_08_000300_add_columns
Migrated:  2017_05_08_000300_add_columns (222.64ms)
Migrating: 2017_06_11_000300_create_payments_and_payment_logs_table
Migrated:  2017_06_11_000300_create_payments_and_payment_logs_table (45.96ms)
Migrating: 2017_08_23_000300_create_themes_table
Migrated:  2017_08_23_000300_create_themes_table (34.15ms)
Migrating: 2018_01_23_000300_create_language_translations_table
Migrated:  2018_01_23_000300_create_language_translations_table (110.16ms)
Migrating: 2018_03_30_000300_create_extension_settings_table
Migrated:  2018_03_30_000300_create_extension_settings_table (71.82ms)
Migrating: 2018_06_12_000300_rename_model_class_names_to_morph_map_custom_names
Migrated:  2018_06_12_000300_rename_model_class_names_to_morph_map_custom_names (4.30ms)
Migrating: 2018_10_19_000300_create_media_attachments_table
Migrated:  2018_10_19_000300_create_media_attachments_table (93.86ms)
Migrating: 2018_10_21_131033_create_queue_table
Migrated:  2018_10_21_131033_create_queue_table (50.94ms)
Migrating: 2018_10_21_131044_create_sessions_table
Migrated:  2018_10_21_131044_create_sessions_table (45.45ms)
Migrating: 2019_04_16_000300_nullify_customer_id_on_addresses_table
Migrated:  2019_04_16_000300_nullify_customer_id_on_addresses_table (33.20ms)
Migrating: 2019_07_01_000300_delete_unused_columns_from_activities_table
Migrated:  2019_07_01_000300_delete_unused_columns_from_activities_table (174.59ms)
Migrating: 2019_07_22_000300_add_user_type_column_to_activities_table
Migrated:  2019_07_22_000300_add_user_type_column_to_activities_table (11.62ms)
Migrating: 2019_07_30_000300_create_mail_partials_table
Migrated:  2019_07_30_000300_create_mail_partials_table (28.45ms)
Migrating: 2020_02_05_000300_delete_stale_unused_table
Migrated:  2020_02_05_000300_delete_stale_unused_table (77.82ms)
Migrating: 2020_04_16_000300_drop_stale_unused_columns
Migrated:  2020_04_16_000300_drop_stale_unused_columns (150.94ms)
Migrating: 2020_05_24_000300_create_request_logs_table
Migrated:  2020_05_24_000300_create_request_logs_table (29.86ms)
Migrating: 2021_07_20_000300_add_uuid_column_to_failed_jobs_table
Migrated:  2021_07_20_000300_add_uuid_column_to_failed_jobs_table (64.81ms)
Migrating: 2021_07_20_172212_create_job_batches_table
Migrated:  2021_07_20_172212_create_job_batches_table (50.18ms)
Migrating: 2021_07_20_172321_create_cache_table
Migrated:  2021_07_20_172321_create_cache_table (45.51ms)
Migrating: 2021_09_06_010000_add_timestamps_to_tables
Migrated:  2021_09_06_010000_add_timestamps_to_tables (387.60ms)
Migrating: 2021_10_22_010000_make_primary_key_bigint_all_tables
Migrated:  2021_10_22_010000_make_primary_key_bigint_all_tables (580.65ms)
Migrating: 2021_10_25_010000_add_foreign_key_constraints_to_tables
Migrated:  2021_10_25_010000_add_foreign_key_constraints_to_tables (154.02ms)
Migrated app System
Migrating: 2017_08_25_000300_create_location_areas_table
Migrated:  2017_08_25_000300_create_location_areas_table (17.44ms)
Migrating: 2017_08_25_000300_create_menu_categories_table
Migrated:  2017_08_25_000300_create_menu_categories_table (62.14ms)
Migrating: 2018_01_19_000300_add_hash_columns_on_orders_reservations_table
Migrated:  2018_01_19_000300_add_hash_columns_on_orders_reservations_table (58.11ms)
Migrating: 2018_04_06_000300_drop_unique_on_order_totals_table
Migrated:  2018_04_06_000300_drop_unique_on_order_totals_table (94.90ms)
Migrating: 2018_04_12_000300_modify_columns_on_orders_reservations_table
Migrated:  2018_04_12_000300_modify_columns_on_orders_reservations_table (52.00ms)
Migrating: 2018_05_21_000300_drop_redundant_columns_on_kitchen_tables
Migrated:  2018_05_21_000300_drop_redundant_columns_on_kitchen_tables (108.81ms)
Migrating: 2018_05_29_000300_add_columns_on_location_areas_table
Migrated:  2018_05_29_000300_add_columns_on_location_areas_table (14.36ms)
Migrating: 2018_06_12_000300_create_locationables_table
Migrated:  2018_06_12_000300_create_locationables_table (21.67ms)
Migrating: 2018_07_04_000300_create_user_preferences_table
Migrated:  2018_07_04_000300_create_user_preferences_table (25.17ms)
Migrating: 2018_10_09_000300_auto_increment_on_order_totals_table
Migrated:  2018_10_09_000300_auto_increment_on_order_totals_table (49.72ms)
Migrating: 2019_04_09_000300_auto_increment_on_user_preferences_table
Migrated:  2019_04_09_000300_auto_increment_on_user_preferences_table (68.88ms)
Migrating: 2019_07_02_000300_add_columns_on_menu_specials_table
Migrated:  2019_07_02_000300_add_columns_on_menu_specials_table (61.85ms)
Migrating: 2019_07_16_000300_create_reservation_tables_table
Migrated:  2019_07_16_000300_create_reservation_tables_table (71.92ms)
Migrating: 2019_07_21_000300_change_sort_value_ratings_to_config_on_settings_table
Migrated:  2019_07_21_000300_change_sort_value_ratings_to_config_on_settings_table (1.68ms)
Migrating: 2019_11_08_000300_add_selected_columns_to_menu_options_table
Migrated:  2019_11_08_000300_add_selected_columns_to_menu_options_table (20.42ms)
Migrating: 2020_02_18_000400_create_staffs_groups_and_locations_table
Migrated:  2020_02_18_000400_create_staffs_groups_and_locations_table (83.12ms)
Migrating: 2020_02_21_000400_create_staff_roles_table
Migrated:  2020_02_21_000400_create_staff_roles_table (50.34ms)
Migrating: 2020_02_22_000300_remove_add_columns_on_staff_staff_groups_table
Migrated:  2020_02_22_000300_remove_add_columns_on_staff_staff_groups_table (92.80ms)
Migrating: 2020_02_25_000300_create_assignable_logs_table
Migrated:  2020_02_25_000300_create_assignable_logs_table (161.67ms)
Migrating: 2020_03_18_000300_add_quantity_column_to_order_menu_options_table
Migrated:  2020_03_18_000300_add_quantity_column_to_order_menu_options_table (11.28ms)
Migrating: 2020_04_05_000300_create_payment_profiles_table
Migrated:  2020_04_05_000300_create_payment_profiles_table (43.92ms)
Migrating: 2020_04_16_000300_drop_stale_unused_columns
Migrated:  2020_04_16_000300_drop_stale_unused_columns (117.07ms)
Migrating: 2020_05_31_000300_drop_more_unused_columns
Migrated:  2020_05_31_000300_drop_more_unused_columns (397.85ms)
Migrating: 2020_06_11_000300_create_menu_mealtimes_table
Migrated:  2020_06_11_000300_create_menu_mealtimes_table (92.70ms)
Migrating: 2020_08_16_000300_modify_columns_on_tables_reservations_table
Migrated:  2020_08_16_000300_modify_columns_on_tables_reservations_table (25.43ms)
Migrating: 2020_08_18_000300_create_allergens_table
Migrated:  2020_08_18_000300_create_allergens_table (86.01ms)
Migrating: 2020_09_28_000300_add_refund_columns_to_payment_logs_table
Migrated:  2020_09_28_000300_add_refund_columns_to_payment_logs_table (12.73ms)
Migrating: 2020_12_13_000300_merge_staffs_locations_into_locationables_table
Migrated:  2020_12_13_000300_merge_staffs_locations_into_locationables_table (8.65ms)
Migrating: 2020_12_22_000300_add_priority_column_to_location_areas_table
Migrated:  2020_12_22_000300_add_priority_column_to_location_areas_table (15.82ms)
Migrating: 2021_01_04_000300_add_update_related_column_to_menu_options_table
Migrated:  2021_01_04_000300_add_update_related_column_to_menu_options_table (14.12ms)
Migrating: 2021_01_04_010000_add_order_time_is_asap_on_orders_table
Migrated:  2021_01_04_010000_add_order_time_is_asap_on_orders_table (20.00ms)
Migrating: 2021_04_23_010000_remove_unused_columns
Migrated:  2021_04_23_010000_remove_unused_columns (224.75ms)
Migrating: 2021_05_26_010000_alter_order_type_columns
Migrated:  2021_05_26_010000_alter_order_type_columns (33.77ms)
Migrating: 2021_05_29_010000_add_is_summable_on_order_totals_table
Migrated:  2021_05_29_010000_add_is_summable_on_order_totals_table (16.37ms)
Migrating: 2021_07_20_010000_add_columns_default_value
Migrated:  2021_07_20_010000_add_columns_default_value (51.01ms)
Migrating: 2021_09_03_010000_make_serialize_columns_json
Migrated:  2021_09_03_010000_make_serialize_columns_json (197.98ms)
Migrating: 2021_09_06_010000_add_timestamps_to_tables
Migrated:  2021_09_06_010000_add_timestamps_to_tables (1,165.63ms)
Migrating: 2021_10_22_010000_make_primary_key_bigint_all_tables
Migrated:  2021_10_22_010000_make_primary_key_bigint_all_tables (1,155.18ms)
Migrating: 2021_10_25_010000_add_foreign_key_constraints_to_tables
Migrated:  2021_10_25_010000_add_foreign_key_constraints_to_tables (3,242.49ms)
Migrated app Admin
Nothing to migrate.
Migrated app Main
Seeded System 
Done. Migrating application and extensions...
Admin user admin created!

*********************************
*     Installation Complete     *
*********************************
```

## The Testing

I've tested this as part of my [Docker testing repo](https://github.com/othyn/tastyigniter-docker-testing/blob/main/core/install_dev.sh) in which I have a fully unattended working installation of TastyIgniter building into the Docker container and accessible on localhost post container build & install.

## The Docs

I've also submitted a [mirror PR to this one over at the docs repo](https://github.com/tastyigniter/docs/pull/21) documenting this change underneath the existing Command-line installation docs in a dedicated unattended installation heading.