### PR TITLE
Feature: pipelines

### DIFF
--- a/app/admin/classes/BaseWidget.php
+++ b/app/admin/classes/BaseWidget.php
@@ -2,6 +2,7 @@
 
 namespace Admin\Classes;
 
+use Admin\Traits\HasPipeline;
 use Admin\Traits\LocationAwareWidget;
 use Admin\Traits\WidgetMaker;
 use Igniter\Flame\Support\Extendable;
@@ -17,13 +18,14 @@ use System\Traits\ViewMaker;
  */
 class BaseWidget extends Extendable
 {
-    use WidgetMaker;
-    use SessionMaker;
-    use ViewMaker;
     use AssetMaker;
     use ConfigMaker;
     use EventEmitter;
+    use HasPipeline;
     use LocationAwareWidget;
+    use SessionMaker;
+    use ViewMaker;
+    use WidgetMaker;
 
     /**
      * @var \Admin\Classes\AdminController Admin controller object.

--- a/app/admin/classes/PipelinePayload.php
+++ b/app/admin/classes/PipelinePayload.php
@@ -10,11 +10,13 @@ class PipelinePayload
     private $caller;
     private $context;
     private $data;
+    private $extra;
 
-    public function __construct($caller, $context)
+    public function __construct($caller, $context, $extra = null)
     {
         $this->caller = $caller;
         $this->context = $context;
+        $this->extra = $extra;
     }
 
     public function caller()
@@ -35,5 +37,10 @@ class PipelinePayload
 
         $this->data = $data;
         return $this;
+    }
+
+    public function extra()
+    {
+        return $this->extra;
     }
 }

--- a/app/admin/classes/PipelinePayload.php
+++ b/app/admin/classes/PipelinePayload.php
@@ -36,6 +36,7 @@ class PipelinePayload
         }
 
         $this->data = $data;
+
         return $this;
     }
 

--- a/app/admin/classes/PipelinePayload.php
+++ b/app/admin/classes/PipelinePayload.php
@@ -11,24 +11,20 @@ class PipelinePayload
     private $context;
     private $data;
 
-    public function caller($caller = null)
+    public function __construct($caller, $context)
     {
-        if (is_null($caller)) {
-            return $this->caller;
-        }
-
         $this->caller = $caller;
-        return $this;
+        $this->context = $context;
     }
 
-    public function context($context = null)
+    public function caller()
     {
-        if (is_null($context)) {
-            return $this->context;
-        }
+        return $this->caller;
+    }
 
-        $this->context = $context;
-        return $this;
+    public function context()
+    {
+        return $this->context;
     }
 
     public function data($data = null)

--- a/app/admin/classes/PipelinePayload.php
+++ b/app/admin/classes/PipelinePayload.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Admin\Classes;
+
+/**
+ * Pipeline Payload 'helper' passed to external extensions
+ */
+class PipelinePayload
+{
+    private $caller;
+    private $context;
+    private $data;
+
+    public function caller($caller = null)
+    {
+        if (is_null($caller)) {
+            return $this->caller;
+        }
+
+        $this->caller = $caller;
+        return $this;
+    }
+
+    public function context($context = null)
+    {
+        if (is_null($context)) {
+            return $this->context;
+        }
+
+        $this->context = $context;
+        return $this;
+    }
+
+    public function data($data = null)
+    {
+        if (is_null($data)) {
+            return $this->data;
+        }
+
+        $this->data = $data;
+        return $this;
+    }
+}

--- a/app/admin/traits/HasPipeline.php
+++ b/app/admin/traits/HasPipeline.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Admin\Traits;
+
+use Illuminate\Pipeline\Pipeline;
+
+/**
+ * Has Pipeline Trait Class
+ */
+trait HasPipeline
+{
+    /**
+     * @var array of registered pipelines
+     */
+    protected static $registeredPipelines = [];
+
+    public function callPipeline($callingContext, $payload)
+    {
+        $payloadClass = (new \ReflectionClass(self::class))->getName();
+
+        $pipes = collect(self::$registeredPipelines)
+                    ->filter(function ($contexts, $klass) use ($payloadClass, $callingContext) {
+                        if (! in_array($klass, ['*', $payloadClass])) {
+                            return [];
+                        }
+
+                        return $contexts->filter(function ($pipelines, $pipelineContext) use ($callingContext) {
+                            if (! in_array($pipelineContext, ['*', $callingContext])) {
+                                return [];
+                            }
+
+                            return $pipelines;
+                        });
+                    })
+                    ->filter()
+                    ->flatten()
+                    ->values();
+
+        if (empty($pipes)) {
+            return $payload;
+        }
+
+        return app(Pipeline::class)
+            ->send($payload)
+            ->through($pipes)
+            ->thenReturn();
+    }
+
+    // register a pipeline by * for all classes
+    // or by classname (eg Admin\Widgets\Lists::class)
+    public static function registerPipeline($klass, $context, $pipelineClass)
+    {
+        if (! array_get(self::$registeredPipelines, $klass, false)) {
+            self::$registeredPipelines[$klass] = [];
+        }
+
+        if (! array_get(self::$registeredPipelines[$klass], $context, false)) {
+            self::$registeredPipelines[$klass][$context] = [];
+        }
+
+        self::$registeredPipelines[$klass][$context] = $pipelineClass;
+    }
+}

--- a/app/admin/traits/HasPipeline.php
+++ b/app/admin/traits/HasPipeline.php
@@ -15,7 +15,7 @@ trait HasPipeline
      */
     protected static $registeredPipelines = [];
 
-    public function callPipeline($caller, $callingContext, $data)
+    public function callPipeline($caller, $callingContext, $data, $extra = null)
     {
         $pipes = self::$registeredPipelines;
 
@@ -27,7 +27,7 @@ trait HasPipeline
             $caller = get_class($caller);
         }
 
-        $payload = (new PipelinePayload($caller, $callingContext))
+        $payload = (new PipelinePayload($caller, $callingContext, $extra))
             ->data($data);
 
         $pipelineResponse = app(Pipeline::class)

--- a/app/admin/traits/HasPipeline.php
+++ b/app/admin/traits/HasPipeline.php
@@ -16,22 +16,14 @@ trait HasPipeline
 
     public function callPipeline($callingContext, $payload)
     {
-        $payloadClass = (new \ReflectionClass(self::class))->getName();
-
         $pipes = collect(self::$registeredPipelines)
-            ->filter(function ($contexts, $klass) use ($payloadClass, $callingContext) {
-                        if (!in_array($klass, ['*', $payloadClass])) {
-                            return [];
-                        }
+            ->filter(function ($pipelines, $context) use ($callingContext) {
+                if (!in_array($context, ['*', $callingContext])) {
+                    return [];
+                }
 
-                        return $contexts->filter(function ($pipelines, $pipelineContext) use ($callingContext) {
-                            if (!in_array($pipelineContext, ['*', $callingContext])) {
-                                return [];
-                            }
-
-                            return $pipelines;
-                        });
-                    })
+                return $pipelines;
+            })
             ->filter()
             ->flatten()
             ->values();
@@ -46,18 +38,14 @@ trait HasPipeline
             ->thenReturn();
     }
 
-    // register a pipeline by * for all classes
+    // register a pipeline by * for all contexts
     // or by classname (eg Admin\Widgets\Lists::class)
-    public static function registerPipeline($klass, $context, $pipelineClass)
+    public static function registerPipeline($context, $pipelineClass)
     {
-        if (!array_get(self::$registeredPipelines, $klass, false)) {
-            self::$registeredPipelines[$klass] = [];
+        if (!array_get(self::$registeredPipelines, $context, false)) {
+            self::$registeredPipelines[$context] = [];
         }
 
-        if (!array_get(self::$registeredPipelines[$klass], $context, false)) {
-            self::$registeredPipelines[$klass][$context] = [];
-        }
-
-        self::$registeredPipelines[$klass][$context] = $pipelineClass;
+        self::$registeredPipelines[$context] = $pipelineClass;
     }
 }

--- a/app/admin/traits/HasPipeline.php
+++ b/app/admin/traits/HasPipeline.php
@@ -19,22 +19,22 @@ trait HasPipeline
         $payloadClass = (new \ReflectionClass(self::class))->getName();
 
         $pipes = collect(self::$registeredPipelines)
-                    ->filter(function ($contexts, $klass) use ($payloadClass, $callingContext) {
-                        if (! in_array($klass, ['*', $payloadClass])) {
+            ->filter(function ($contexts, $klass) use ($payloadClass, $callingContext) {
+                        if (!in_array($klass, ['*', $payloadClass])) {
                             return [];
                         }
 
                         return $contexts->filter(function ($pipelines, $pipelineContext) use ($callingContext) {
-                            if (! in_array($pipelineContext, ['*', $callingContext])) {
+                            if (!in_array($pipelineContext, ['*', $callingContext])) {
                                 return [];
                             }
 
                             return $pipelines;
                         });
                     })
-                    ->filter()
-                    ->flatten()
-                    ->values();
+            ->filter()
+            ->flatten()
+            ->values();
 
         if (empty($pipes)) {
             return $payload;
@@ -50,11 +50,11 @@ trait HasPipeline
     // or by classname (eg Admin\Widgets\Lists::class)
     public static function registerPipeline($klass, $context, $pipelineClass)
     {
-        if (! array_get(self::$registeredPipelines, $klass, false)) {
+        if (!array_get(self::$registeredPipelines, $klass, false)) {
             self::$registeredPipelines[$klass] = [];
         }
 
-        if (! array_get(self::$registeredPipelines[$klass], $context, false)) {
+        if (!array_get(self::$registeredPipelines[$klass], $context, false)) {
             self::$registeredPipelines[$klass][$context] = [];
         }
 

--- a/app/admin/traits/HasPipeline.php
+++ b/app/admin/traits/HasPipeline.php
@@ -27,9 +27,7 @@ trait HasPipeline
             $caller = get_class($caller);
         }
 
-        $payload = (new PipelinePayload)
-            ->caller($caller)
-            ->context($callingContext)
+        $payload = (new PipelinePayload($caller, $callingContext))
             ->data($data);
 
         $pipelineResponse = app(Pipeline::class)

--- a/app/admin/widgets/Calendar.php
+++ b/app/admin/widgets/Calendar.php
@@ -91,6 +91,8 @@ class Calendar extends BaseWidget
             $generatedEvents = $eventResults[0];
         }
 
+        $generatedEvents = $this->callPipeline($this->controller, 'generateEvents', $generatedEvents);
+
         return [
             'generatedEvents' => $generatedEvents,
         ];

--- a/app/admin/widgets/Form.php
+++ b/app/admin/widgets/Form.php
@@ -320,16 +320,20 @@ class Form extends BaseWidget
         $result = [];
         $saveData = $this->getSaveData();
 
-        // Extensibility
+        // @deprecated remove before v5
         $dataHolder = (object)['data' => $saveData];
         $this->fireSystemEvent('admin.form.beforeRefresh', [$dataHolder]);
         $saveData = $dataHolder->data;
 
+        $saveData = $this->callPipeline($this->controller, 'beforeRefresh', $saveData);
+
         $this->setFormValues($saveData);
         $this->prepareVars();
 
-        // Extensibility
+        // @deprecated remove before v5
         $this->fireSystemEvent('admin.form.refreshFields', [$this->allFields]);
+
+        $this->allFields = $this->callPipeline($this->controller, 'refreshFields', $this->allFields);
 
         if (($updateFields = post('fields')) && is_array($updateFields)) {
             foreach ($updateFields as $field) {
@@ -346,12 +350,14 @@ class Form extends BaseWidget
             $result = ['#'.$this->getId() => $this->makePartial('form')];
         }
 
-        // Extensibility
+        // @deprecated remove before v5
         $eventResults = $this->fireSystemEvent('admin.form.refresh', [$result], FALSE);
 
         foreach ($eventResults as $eventResult) {
             $result = $eventResult + $result;
         }
+
+        $result = $this->callPipeline($this->controller, 'refresh', $result);
 
         return $result;
     }
@@ -860,7 +866,8 @@ class Form extends BaseWidget
             return;
         }
 
-        // Extensibility
+        // @deprecated remove before v5
+        // Ryan: I didnt add a pipeline here as I think extendFields is enough
         $this->fireSystemEvent('admin.form.extendFieldsBefore');
 
         // Outside fields
@@ -879,8 +886,10 @@ class Form extends BaseWidget
         $this->allTabs->primary = new FormTabs(FormTabs::SECTION_PRIMARY, $this->tabs);
         $this->addFields($this->tabs['fields'], FormTabs::SECTION_PRIMARY);
 
-        // Extensibility
+        // @deprecated remove before v5
         $this->fireSystemEvent('admin.form.extendFields', [$this->allFields]);
+
+        $this->allFields = $this->callPipeline($this->controller, 'extendFields', $this->allFields);
 
         // Check that the form field matches the active location context
         foreach ($this->allFields as $field) {

--- a/app/admin/widgets/Lists.php
+++ b/app/admin/widgets/Lists.php
@@ -7,6 +7,7 @@ use Admin\Classes\ListColumn;
 use Admin\Classes\ToolbarButton;
 use Admin\Classes\Widgets;
 use Admin\Facades\AdminAuth;
+use Admin\Traits\HasPipeline;
 use Admin\Traits\LocationAwareWidget;
 use Carbon\Carbon;
 use Exception;
@@ -20,6 +21,7 @@ use Illuminate\Support\Facades\DB;
 
 class Lists extends BaseWidget
 {
+    use HasPipeline;
     use LocationAwareWidget;
 
     /**
@@ -268,7 +270,7 @@ class Lists extends BaseWidget
         $withs = [];
 
         // Extensibility
-        $this->fireSystemEvent('admin.list.extendQueryBefore', [$query]);
+        $query = $this->callPipeline('extendQueryBefore', $query);
 
         // Prepare searchable column names
         $primarySearchable = [];
@@ -385,9 +387,7 @@ class Lists extends BaseWidget
         $query->select($selects);
 
         // Extensibility
-        if ($event = $this->fireSystemEvent('admin.list.extendQuery', [$query], TRUE)) {
-            return $event;
-        }
+        $query = $this->callPipeline('extendQuery', $query);
 
         return $query;
     }

--- a/app/admin/widgets/Lists.php
+++ b/app/admin/widgets/Lists.php
@@ -7,7 +7,6 @@ use Admin\Classes\ListColumn;
 use Admin\Classes\ToolbarButton;
 use Admin\Classes\Widgets;
 use Admin\Facades\AdminAuth;
-use Admin\Traits\HasPipeline;
 use Admin\Traits\LocationAwareWidget;
 use Carbon\Carbon;
 use Exception;
@@ -21,7 +20,6 @@ use Illuminate\Support\Facades\DB;
 
 class Lists extends BaseWidget
 {
-    use HasPipeline;
     use LocationAwareWidget;
 
     /**

--- a/app/admin/widgets/Lists.php
+++ b/app/admin/widgets/Lists.php
@@ -271,7 +271,7 @@ class Lists extends BaseWidget
         // @deprecated, remove before v5
         $this->fireSystemEvent('admin.list.extendQueryBefore', [$query]);
 
-        $query = $this->callPipeline('extendQueryBefore', $query);
+        $query = $this->callPipeline($this->controller, 'extendQueryBefore', $query);
 
         // Prepare searchable column names
         $primarySearchable = [];
@@ -388,7 +388,7 @@ class Lists extends BaseWidget
         $query->select($selects);
 
         // Extensibility
-        $query = $this->callPipeline('extendQuery', $query);
+        $query = $this->callPipeline($this->controller, 'extendQuery', $query);
 
         // @deprecated, remove before v5
         if ($event = $this->fireSystemEvent('admin.list.extendQuery', [$query], TRUE)) {
@@ -487,7 +487,7 @@ class Lists extends BaseWidget
         }
 
         // Extensibility
-        $this->columns = $this->callPipeline('extendColumns', $this->columns);
+        $this->columns = $this->callPipeline($this->controller, 'extendColumns', $this->columns);
 
         $this->addColumns($this->columns);
 
@@ -635,7 +635,7 @@ class Lists extends BaseWidget
         $value = lang($column->label);
 
         // Extensibility
-        $payload = $this->callPipeline('overrideHeaderValue', ['column' => $column, 'value' => $value]);
+        $payload = $this->callPipeline($this->controller, 'overrideHeaderValue', ['column' => $column, 'value' => $value]);
         $value = $payload['value'] ?? null;
 
         // @deprecated, remove before v5
@@ -670,7 +670,7 @@ class Lists extends BaseWidget
             $value = $column->defaults;
 
         // Extensibility
-        $payload = $this->callPipeline('overrideColumnValue', ['column' => $column, 'value' => $value]);
+        $payload = $this->callPipeline($this->controller, 'overrideColumnValue', ['column' => $column, 'value' => $value]);
         $value = $payload['value'] ?? null;
 
         // @deprecated, remove before v5
@@ -690,8 +690,8 @@ class Lists extends BaseWidget
         $result = $column->attributes;
 
         // Extensibility
-        $payload = $this->callPipeline('overrideColumnValue', ['column' => $column, 'value' => $value]);
-        $value = $payload['value'] ?? null;
+        $payload = $this->callPipeline($this->controller, 'overrideColumnValue', ['column' => $column, 'value' => $result]);
+        $result = $payload['value'] ?? null;
 
         // @deprecated, remove before v5
         if ($response = $this->fireSystemEvent('admin.list.overrideColumnValue', [$record, $column, $result], TRUE)) {
@@ -1226,7 +1226,7 @@ class Lists extends BaseWidget
 
     protected function getAvailableBulkActions()
     {
-        $this->bulkActions = $this->callPipeline('extendBulkActions', $this->bulkActions);
+        $this->bulkActions = $this->callPipeline($this->controller, 'extendBulkActions', $this->bulkActions);
 
         // @deprecated, remove before v5
         $this->fireSystemEvent('admin.list.extendBulkActions');

--- a/app/admin/widgets/Lists.php
+++ b/app/admin/widgets/Lists.php
@@ -270,6 +270,9 @@ class Lists extends BaseWidget
         $withs = [];
 
         // Extensibility
+        // @deprecated, remove before v5
+        $this->fireSystemEvent('admin.list.extendQueryBefore', [$query]);
+
         $query = $this->callPipeline('extendQueryBefore', $query);
 
         // Prepare searchable column names
@@ -388,6 +391,11 @@ class Lists extends BaseWidget
 
         // Extensibility
         $query = $this->callPipeline('extendQuery', $query);
+
+        // @deprecated, remove before v5
+        if ($event = $this->fireSystemEvent('admin.list.extendQuery', [$query], TRUE)) {
+            return $event;
+        }
 
         return $query;
     }

--- a/app/admin/widgets/Lists.php
+++ b/app/admin/widgets/Lists.php
@@ -486,9 +486,12 @@ class Lists extends BaseWidget
             throw new Exception(sprintf(lang('admin::lang.list.missing_column'), get_class($this->controller)));
         }
 
+        // Extensibility
+        $this->columns = $this->callPipeline('extendColumns', $this->columns);
+
         $this->addColumns($this->columns);
 
-        // Extensibility
+        // @deprecated, remove before v5
         $this->fireSystemEvent('admin.list.extendColumns');
 
         // Use a supplied column order
@@ -632,6 +635,10 @@ class Lists extends BaseWidget
         $value = lang($column->label);
 
         // Extensibility
+        $payload = $this->callPipeline('overrideHeaderValue', ['column' => $column, 'value' => $value]);
+        $value = $payload['value'] ?? null;
+
+        // @deprecated, remove before v5
         if ($response = $this->fireSystemEvent('admin.list.overrideHeaderValue', [$column, $value], TRUE)) {
             $value = $response;
         }
@@ -663,6 +670,10 @@ class Lists extends BaseWidget
             $value = $column->defaults;
 
         // Extensibility
+        $payload = $this->callPipeline('overrideColumnValue', ['column' => $column, 'value' => $value]);
+        $value = $payload['value'] ?? null;
+
+        // @deprecated, remove before v5
         if ($response = $this->fireSystemEvent('admin.list.overrideColumnValue', [$record, $column, $value], TRUE)) {
             $value = $response;
         }
@@ -679,6 +690,10 @@ class Lists extends BaseWidget
         $result = $column->attributes;
 
         // Extensibility
+        $payload = $this->callPipeline('overrideColumnValue', ['column' => $column, 'value' => $value]);
+        $value = $payload['value'] ?? null;
+
+        // @deprecated, remove before v5
         if ($response = $this->fireSystemEvent('admin.list.overrideColumnValue', [$record, $column, $result], TRUE)) {
             $result = $response;
         }
@@ -1211,6 +1226,9 @@ class Lists extends BaseWidget
 
     protected function getAvailableBulkActions()
     {
+        $this->bulkActions = $this->callPipeline('extendBulkActions', $this->bulkActions);
+
+        // @deprecated, remove before v5
         $this->fireSystemEvent('admin.list.extendBulkActions');
 
         $allBulkActions = $this->makeBulkActionButtons($this->bulkActions);

--- a/app/admin/widgets/Menu.php
+++ b/app/admin/widgets/Menu.php
@@ -166,6 +166,8 @@ class Menu extends BaseWidget
      */
     public function getItems()
     {
+        $this->allItems = $this->callPipeline($this->controller, 'getItems', $this->allItems);
+
         return $this->allItems;
     }
 

--- a/app/admin/widgets/Table.php
+++ b/app/admin/widgets/Table.php
@@ -173,6 +173,8 @@ class Table extends BaseWidget
 
         $eventResults = $this->fireEvent('table.getRecords', [$offset, $limit, $search], TRUE);
 
+        $eventResults = $this->callPipeline($this->controller, 'getRecords', $eventResults, ['offset' => $offset, 'limit' => $limit, 'query' => $search]);
+
         $records = $eventResults->getCollection()->toArray();
 
         return [
@@ -192,6 +194,8 @@ class Table extends BaseWidget
         if (count($eventResults)) {
             $options = $eventResults[0];
         }
+
+        $options = $this->callPipeline($this->controller, 'getDropdownOptions', $options, ['column' => $columnName, 'rowData' => $rowData]);
 
         return [
             'options' => $options,

--- a/app/admin/widgets/Toolbar.php
+++ b/app/admin/widgets/Toolbar.php
@@ -75,13 +75,19 @@ class Toolbar extends BaseWidget
             $this->buttons = [];
         }
 
+        // @deprecated remove before v5
         $this->fireSystemEvent('admin.toolbar.extendButtonsBefore');
+
+        $this->buttons = $this->callPipeline($this->controller, 'extendButtonsBefore', $this->buttons);
 
         $this->prepareButtons();
 
         $this->addButtons($this->buttons);
 
+        // @deprecated remove before v5
         $this->fireSystemEvent('admin.toolbar.extendButtons', [$this->allButtons]);
+
+        $this->allButtons = $this->callPipeline($this->controller, 'extendButtons', $this->allButtons);
 
         $this->buttonsDefined = TRUE;
     }


### PR DESCRIPTION
Ok here is a proof of concept. 

Basic idea is we provide a pipeline trait, which I've added to the list widget. Then instead of listening for an event response, we pass the query to the pipeline, which looks for any registered listeners.

Listeners can be registered on widgets eg

`Admin\Widgets\Lists::registerPipeline('*', 'extendQuery', MyPipeline::class);`

or

`Admin\Widgets\Lists::registerPipeline('Admin\Controllers\Orders', 'extendQuery', MyPipeline::class);`

or

`Admin\Widgets\Lists::registerPipeline('Admin\Controllers\Orders', '*', MyPipeline::class);`

We then create a stub for Pipelines `php artisan igniter:make:pipeline` which makes it easy for devs to register their own. It will be this sort of format:

```
class MyPipeline
{
    public function handle($payload, Closure $next)
    {
        // do something with $payload
        return $next($payload);
    }
}
```