### PR TITLE
Allow Language + Timezone to be chosen during install

### DIFF
--- a/app/system/console/commands/IgniterInstall.php
+++ b/app/system/console/commands/IgniterInstall.php
@@ -9,6 +9,7 @@ use Admin\Models\Staff_groups_model;
 use Admin\Models\Staff_roles_model;
 use Admin\Models\Staffs_model;
 use Admin\Models\Users_model;
+use DateTimeZone;
 use Igniter\Flame\Support\ConfigRewrite;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\App;
@@ -144,7 +145,9 @@ class IgniterInstall extends Command
         DatabaseSeeder::$siteName = $this->ask('Site Name', DatabaseSeeder::$siteName);
         DatabaseSeeder::$siteUrl = $this->ask('Site URL', Config::get('app.url'));
         DatabaseSeeder::$siteLanguage = $this->ask('Site Language', DatabaseSeeder::$siteLanguage);
-        DatabaseSeeder::$siteTimezone = $this->ask('Site Timezone', DatabaseSeeder::$siteTimezone);
+
+        $availableTimezones = DateTimeZone;::listIdentifiers(DateTimeZone::ALL);
+        DatabaseSeeder::$siteTimezone = $this->choice('Site Timezone', $availableTimezones, $availableTimezones[DatabaseSeeder::$siteTimezone] ?? 0);
 
         DatabaseSeeder::$seedDemo = $this->confirm('Install demo data?', DatabaseSeeder::$seedDemo);
 

--- a/app/system/console/commands/IgniterInstall.php
+++ b/app/system/console/commands/IgniterInstall.php
@@ -143,6 +143,8 @@ class IgniterInstall extends Command
 
         DatabaseSeeder::$siteName = $this->ask('Site Name', DatabaseSeeder::$siteName);
         DatabaseSeeder::$siteUrl = $this->ask('Site URL', Config::get('app.url'));
+        DatabaseSeeder::$siteLanguage = $this->ask('Site Language', DatabaseSeeder::$siteLanguage);
+        DatabaseSeeder::$siteTimezone = $this->ask('Site Timezone', DatabaseSeeder::$siteTimezone);
 
         DatabaseSeeder::$seedDemo = $this->confirm('Install demo data?', DatabaseSeeder::$seedDemo);
 

--- a/app/system/console/commands/IgniterInstall.php
+++ b/app/system/console/commands/IgniterInstall.php
@@ -210,6 +210,8 @@ class IgniterInstall extends Command
         setting()->set('site_email', DatabaseSeeder::$siteEmail);
         setting()->set('sender_name', DatabaseSeeder::$siteName);
         setting()->set('sender_email', DatabaseSeeder::$siteEmail);
+        setting()->set('timezone', DatabaseSeeder::$siteTimezone);
+        setting()->set('default_language', DatabaseSeeder::$siteLanguage);
         setting()->set('customer_group_id', Customer_groups_model::first()->customer_group_id);
         setting()->save();
 

--- a/app/system/database/seeds/DatabaseSeeder.php
+++ b/app/system/database/seeds/DatabaseSeeder.php
@@ -16,6 +16,10 @@ class DatabaseSeeder extends Seeder
 
     public static $seedDemo = TRUE;
 
+    public static $siteLanguage = 'en';
+
+    public static $siteTimezone = 'Europe/London';
+
     /**
      * Run the database seeds.
      * @return void


### PR DESCRIPTION
As referenced in https://github.com/tastyigniter/TastyIgniter/issues/904

Reopen of #908 

This allows timezones to be selected from a list, but language is still a text input. We would really need a list of available locales Tasty supports?