### PR TITLE
Prevents SQL Error when either `subtract_stock` field is NULL

### DIFF
--- a/app/admin/database/migrations/2021_11_28_000300_create_stocks_table.php
+++ b/app/admin/database/migrations/2021_11_28_000300_create_stocks_table.php
@@ -77,7 +77,7 @@ class CreateStocksTable extends Migration
                     'stockable_id' => $menuItem->menu_id,
                     'stockable_type' => 'menus',
                     'quantity' => $menuItem->stock_qty,
-                    'is_tracked' => $menuItem->subtract_stock,
+                    'is_tracked' => (bool)$menuItem->subtract_stock,
                     'created_at' => now()->toDateTimeString(),
                     'updated_at' => now()->toDateTimeString(),
                 ]);
@@ -114,7 +114,7 @@ class CreateStocksTable extends Migration
                     'stockable_id' => $optionValue->option_value_id,
                     'stockable_type' => 'menu_option_values',
                     'quantity' => $optionValue->quantity,
-                    'is_tracked' => $optionValue->subtract_stock,
+                    'is_tracked' => (bool)$optionValue->subtract_stock,
                     'created_at' => now()->toDateTimeString(),
                     'updated_at' => now()->toDateTimeString(),
                 ]);


### PR DESCRIPTION
This might only affect me? 

Upgrading a development env kept failing due to `$menuItem->subtract_stock` and `$optionValue->subtract_stock` both being nullable, while `is_tracked` is not, throwing an error 

```
SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'is_tracked' cannot be null (SQL: insert into `ti_stocks` (`location_id`, `stockable_id`, `stockable_type`, `quantity`, `is_tracked`, `created_at`, `updated_at`) values (2, 4, menu_option_values, 10, ?, 2022-03-08 14:07:37, 2022-03-08 14:07:37))
```

though it's possible that in the regular course of operation, these fields won't ever actually be null. 
