### PR TITLE
Minor fix. Fix menu items sorting based on stock quantity.

### DIFF
--- a/app/admin/models/config/menus_model.php
+++ b/app/admin/models/config/menus_model.php
@@ -105,7 +105,9 @@ $config['list']['columns'] = [
     'stock_qty' => [
         'label' => 'lang:admin::lang.menus.column_stock_qty',
         'type' => 'number',
-        'sortable' => false,
+        'relation' => 'stocks',
+        'select' => 'quantity',
+        'sortable' => TRUE
     ],
     'special_status' => [
         'label' => 'lang:admin::lang.menus.label_special_status',


### PR DESCRIPTION
Enable admin sorting menu items based on their stock quantity.
It was disabled due to wrong SQL query that was build based on
wrong configuration.

It fix [this](https://github.com/tastyigniter/TastyIgniter/issues/957)