### PR TITLE
Set startDate and endDate to today to fix invalid date

### DIFF
--- a/app/admin/widgets/filter/assets/js/datepicker.js
+++ b/app/admin/widgets/filter/assets/js/datepicker.js
@@ -46,10 +46,10 @@
             }
             
             if (this.$el.find('[data-datepicker-range-start]').val() == '')
-                options.startDate = '';
+                options.startDate = moment().startOf('day');
                 
             if (this.$el.find('[data-datepicker-range-end]').val() == '')
-                options.endDate = '';
+                options.endDate = moment().endOf('day');
         }
 
         $el.daterangepicker(options, $.proxy(this.onDateSelected, this))


### PR DESCRIPTION
If startDate or endDate is empty, the date parser will fail and calendar will be filled with NaN dates like the picture below.
You can re-create this by adding a new daterange scope, at the first time you open filter, choose Custom range

<img width="630" alt="image" src="https://user-images.githubusercontent.com/28602861/166871709-122f2e54-33d0-40f0-b777-e7c3c3829f7a.png">

So I suggest use today as startDate and endDate if they are not available