### PR TITLE
fix what seem like typos

### DIFF
--- a/app/admin/formwidgets/mediafinder/assets/js/mediafinder.js
+++ b/app/admin/formwidgets/mediafinder/assets/js/mediafinder.js
@@ -53,7 +53,7 @@
     }
 
     MediaFinder.prototype.onClickConfigButton = function (event) {
-        var self = this,
+        var self = this, modal,
             $container = $(event.target).closest('.media-finder'),
             $mediaIdentifier = $('[data-find-identifier]', $container).val(),
             $modalElement = $('<div/>', {
@@ -66,12 +66,11 @@
             })
 
         $modalElement.html(this.$configTemplate.innerHTML)
-        $modalElement.modal({backdrop: 'static', keyboard: false})
+        modal = new bootstrap.Modal($modalElement, {backdrop: 'static', keyboard: false})
+        modal.show()
 
-        $modalElement.modal('show');
-
-        $modalElement.on('shown.bs.modal', function (event) {
-            $.request(self.options.alias + '::onLoadAttachmentConfig', {
+        $modalElement.one('shown.bs.modal', function (event) {
+            $.request(self.options.alias+'::onLoadAttachmentConfig', {
                 data: {media_id: $mediaIdentifier}
             }).done(function () {
                 $modalElement.find('form').on('ajaxDone', function () {
@@ -80,7 +79,7 @@
             })
         })
 
-        $modalElement.on('hide.bs.modal', function (event) {
+        $modalElement.one('hide.bs.modal', function (event) {
             var $modalElement = $(event.target)
 
             $modalElement.remove()

--- a/app/admin/formwidgets/mediafinder/assets/js/mediafinder.js
+++ b/app/admin/formwidgets/mediafinder/assets/js/mediafinder.js
@@ -68,7 +68,9 @@
         $modalElement.html(this.$configTemplate.innerHTML)
         $modalElement.modal({backdrop: 'static', keyboard: false})
 
-        $modalElement.one('shown.bs.modal', function (event) {
+        $modalElement.modal('show');
+
+        $modalElement.on('shown.bs.modal', function (event) {
             $.request(self.options.alias + '::onLoadAttachmentConfig', {
                 data: {media_id: $mediaIdentifier}
             }).done(function () {
@@ -78,7 +80,7 @@
             })
         })
 
-        $modalElement.one('hide.bs.modal', function (event) {
+        $modalElement.on('hide.bs.modal', function (event) {
             var $modalElement = $(event.target)
 
             $modalElement.remove()


### PR DESCRIPTION
Hey there! Not sure if I'm missing something here but these are typos right?

Without adding the `.modal('show')` and switching `one()` => `on()`, the media thumbnail attachments config data modal doesn't show up on a fresh installation. 