### PR TITLE
Menu priority rule

### DIFF
--- a/app/admin/requests/Menu.php
+++ b/app/admin/requests/Menu.php
@@ -38,7 +38,7 @@ class Menu extends FormRequest
             'order_restriction.*' => ['nullable', 'string'],
             'menu_status' => ['boolean'],
             'mealtime_id' => ['nullable', 'integer'],
-            'menu_priority' => ['nullable', 'integer'],
+            'menu_priority' => ['min:0', 'integer'],
         ];
     }
 }


### PR DESCRIPTION
Priority cannot be null, change rule to 'min:0' to avoid sql error