### PR TITLE
Adding address auto-completion feature to input address boxes

### DIFF
--- a/app/admin/controllers/Customers.php
+++ b/app/admin/controllers/Customers.php
@@ -58,6 +58,15 @@ class Customers extends \Admin\Classes\AdminController
         parent::__construct();
 
         AdminMenu::setContext('customers', 'users');
+        
+        // auto-complete for filling in street info
+        if( strlen(setting('maps_api_key'))>35 ){
+            $url = 'https://maps.googleapis.com/maps/api/js?key=%s&libraries=places';
+            $this->addJs(sprintf($url, setting('maps_api_key')),
+                ['name' => 'google-maps-js', 'async' => null, 'defer' => null]
+                );
+            $this->addJs('/assets/static/autocomplete.js', 'autocomplete-js');
+        }
     }
 
     public function onImpersonate($context, $recordId = null)

--- a/app/admin/controllers/Customers.php
+++ b/app/admin/controllers/Customers.php
@@ -58,9 +58,9 @@ class Customers extends \Admin\Classes\AdminController
         parent::__construct();
 
         AdminMenu::setContext('customers', 'users');
-        
+
         // auto-complete for filling in street info
-        if( strlen(setting('maps_api_key'))>35 ){
+        if(strlen(setting('maps_api_key')) > 35){
             $url = 'https://maps.googleapis.com/maps/api/js?key=%s&libraries=places';
             $this->addJs(sprintf($url, setting('maps_api_key')),
                 ['name' => 'google-maps-js', 'async' => null, 'defer' => null]

--- a/app/admin/controllers/Locations.php
+++ b/app/admin/controllers/Locations.php
@@ -59,6 +59,10 @@ class Locations extends \Admin\Classes\AdminController
         parent::__construct();
 
         AdminMenu::setContext('locations', 'restaurant');
+
+        // auto-complete for filling in street info (only if google-maps key avail)
+        if( strlen(setting('maps_api_key'))>35 )
+            $this->addJs('/assets/static/autocomplete.js', 'autocomplete-js');
     }
 
     public function remap($action, $params)

--- a/app/admin/controllers/Locations.php
+++ b/app/admin/controllers/Locations.php
@@ -61,7 +61,7 @@ class Locations extends \Admin\Classes\AdminController
         AdminMenu::setContext('locations', 'restaurant');
 
         // auto-complete for filling in street info (only if google-maps key avail)
-        if( strlen(setting('maps_api_key'))>35 )
+        if(strlen(setting('maps_api_key')) > 35)
             $this->addJs('/assets/static/autocomplete.js', 'autocomplete-js');
     }
 

--- a/app/admin/formwidgets/MapArea.php
+++ b/app/admin/formwidgets/MapArea.php
@@ -98,13 +98,13 @@ class MapArea extends BaseFormWidget
         $this->addCss('css/maparea.css', 'maparea-css');
         $this->addJs('js/maparea.js', 'maparea-js');
 
-        // Make the mapview assets available
-        if (strlen($key = setting('maps_api_key'))) {
-            $url = 'https://maps.googleapis.com/maps/api/js?key=%s&libraries=geometry';
-            $this->addJs(sprintf($url, $key),
+        // Make the mapview assets available (if api-key appears valid)
+        if( strlen(setting('maps_api_key'))>35 ){
+            $url = 'https://maps.googleapis.com/maps/api/js?key=%s&libraries=geometry,places';
+            $this->addJs(sprintf($url, setting('maps_api_key')),
                 ['name' => 'google-maps-js', 'async' => null, 'defer' => null]
-            );
-        }
+                );
+        }            
 
         $this->addJs('../../mapview/assets/js/mapview.js', 'mapview-js');
         $this->addJs('../../mapview/assets/js/mapview.shape.js', 'mapview-shape-js');

--- a/app/admin/formwidgets/MapArea.php
+++ b/app/admin/formwidgets/MapArea.php
@@ -99,12 +99,12 @@ class MapArea extends BaseFormWidget
         $this->addJs('js/maparea.js', 'maparea-js');
 
         // Make the mapview assets available (if api-key appears valid)
-        if( strlen(setting('maps_api_key'))>35 ){
+        if(strlen(setting('maps_api_key')) > 35){
             $url = 'https://maps.googleapis.com/maps/api/js?key=%s&libraries=geometry,places';
             $this->addJs(sprintf($url, setting('maps_api_key')),
                 ['name' => 'google-maps-js', 'async' => null, 'defer' => null]
                 );
-        }            
+        }
 
         $this->addJs('../../mapview/assets/js/mapview.js', 'mapview-js');
         $this->addJs('../../mapview/assets/js/mapview.shape.js', 'mapview-shape-js');

--- a/app/admin/formwidgets/MapView.php
+++ b/app/admin/formwidgets/MapView.php
@@ -41,12 +41,13 @@ class MapView extends BaseFormWidget
 
     public function loadAssets()
     {
-        if (strlen($key = setting('maps_api_key'))) {
-            $url = 'https://maps.googleapis.com/maps/api/js?key=%s&libraries=geometry';
-            $this->addJs(sprintf($url, $key),
+        // only available if api-key a likely valid length
+        if( strlen(setting('maps_api_key'))>35 ){
+            $url = 'https://maps.googleapis.com/maps/api/js?key=%s&libraries=geometry,places';
+            $this->addJs(sprintf($url, setting('maps_api_key')),
                 ['name' => 'google-maps-js', 'async' => null, 'defer' => null]
-            );
-        }
+                );
+        }           
 
         $this->addJs('js/mapview.js', 'mapview-js');
         $this->addJs('js/mapview.shape.js', 'mapview-shape-js');

--- a/app/admin/formwidgets/MapView.php
+++ b/app/admin/formwidgets/MapView.php
@@ -42,12 +42,12 @@ class MapView extends BaseFormWidget
     public function loadAssets()
     {
         // only available if api-key a likely valid length
-        if( strlen(setting('maps_api_key'))>35 ){
+        if(strlen(setting('maps_api_key')) > 35){
             $url = 'https://maps.googleapis.com/maps/api/js?key=%s&libraries=geometry,places';
             $this->addJs(sprintf($url, setting('maps_api_key')),
                 ['name' => 'google-maps-js', 'async' => null, 'defer' => null]
                 );
-        }           
+        }
 
         $this->addJs('js/mapview.js', 'mapview-js');
         $this->addJs('js/mapview.shape.js', 'mapview-shape-js');

--- a/app/system/classes/ExtensionManager.php
+++ b/app/system/classes/ExtensionManager.php
@@ -369,7 +369,8 @@ class ExtensionManager
         $class = $namespace.'Extension';
 
         if (!class_exists($class)) {
-            throw new SystemException("Missing Extension class '{$class}' in '{$identifier}', create the Extension class to override extensionMeta() method.");
+		return false;
+		// throw new SystemException("Missing Extension class '{$class}' in '{$identifier}', create the Extension class to override extensionMeta() method.");
         }
 
         $classObj = new $class($this->app);

--- a/assets/static/autocomplete.js
+++ b/assets/static/autocomplete.js
@@ -1,6 +1,6 @@
 /********************************
  * Written by Filipe Laborde / fil@rezox.com
- * version 1.0, June-2024
+ * version 1.1, June-2024
  * 
  * Painless auto-complete form for TastyIgniter to auto-complete address locations
  * 
@@ -16,12 +16,12 @@ function _getElement( field,type='id' ){
 // function to attach google autocomplete to some html element (and fill it's associated form fields)
 function attachAutocomplete( input, type='id', namePrefix='' ) {
     if( !google || !google.maps || !google.maps.places ){
-      console.log( `[autocomplete-js] GoogleMaps 'places' library not loaded, aborting.` );
+      console.log( `[autocomplete-js] v1.1: GoogleMaps 'places' library not loaded, aborting.` );
       if(intervalAutocomplete) clearInterval(intervalAutocomplete);
       intervalAutocomplete = null;
       return false;
     }
-    console.log( `[autocomplete-js] attaching(${type=='id'?'id='+input.id:'name='+input.name})`);
+    console.log( `[autocomplete-js] v1.1: attaching(${type=='id'?'id='+input.id:'name='+input.name})`);
 
     try {
       const autocomplete = new google.maps.places.Autocomplete(input);
@@ -43,8 +43,8 @@ function attachAutocomplete( input, type='id', namePrefix='' ) {
           country: '',
           postcode: '',
           locationId: place.place_id,
-          latitude: place.geometry.location.lat(),
-          longitude: place.geometry.location.lng()
+          lat: place.geometry.location.lat(),
+          lng: place.geometry.location.lng()
         };
 
         // decode google's info block to an addressDetails block we can map to form fields
@@ -72,10 +72,17 @@ function attachAutocomplete( input, type='id', namePrefix='' ) {
           }
         });
         // console.log( ` .. extracted from google addressComponents: `, addressComponents ) // if debugging see Google's fields here
+        
+        // disable auto-lat-long
+        const elAutoLL = document.getElementById('form-field-location-options-auto-lat-lng')
+        if( elAutoLL && elAutoLL.checked ){
+          console.log( `[autocomplete-js] auto lat-long was enabled, disabling.` );
+          elAutoLL.click();
+        }
 
         // fill in details on the form
         input.value = addressDetails.street;
-        ['city','state','postcode'].forEach( name=>{
+        ['city','state','postcode','lat','lng'].forEach( name=>{
           const el = _getElement(namePrefix+name,type); // type=='id' ? document.getElementById(namePrefix+name) : document.getElementByName(namePrefix+name+']');
           if( el ){
             console.log( `[autocomplete-js] field[${type=='id'?'id='+el.id:'name='+el.name}]='${addressDetails[name]}'` );
@@ -84,7 +91,7 @@ function attachAutocomplete( input, type='id', namePrefix='' ) {
             console.log( `[autocomplete-js] invalid element for ${name}!`)
           }
         })
-        
+
         const elSelect = type=='id' && namePrefix=='' && document.getElementById('country') ? document.getElementById('country') :
                         _getElement(namePrefix+'country-id',type)
         if( elSelect ){
@@ -99,7 +106,7 @@ function attachAutocomplete( input, type='id', namePrefix='' ) {
             }
         }
 
-        console.log( `[autocomplete-js] Autocomplete finished; Location: ${addressDetails.latitude},${addressDetails.longitude}` );
+        console.log( `[autocomplete-js] Autocomplete finished; Location: id#${addressDetails.locationId}; (${addressDetails.lat},${addressDetails.lng})` );
       });
     } catch( e ){
       console.log( `[autocomplete-js] Problem with autocomplete:`, e );

--- a/assets/static/autocomplete.js
+++ b/assets/static/autocomplete.js
@@ -1,0 +1,136 @@
+/********************************
+ * Written by Filipe Laborde / fil@rezox.com
+ * version 1.0, June-2024
+ * 
+ * Painless auto-complete form for TastyIgniter to auto-complete address locations
+ * 
+ */
+
+// gets actual element from the name & type; auto-adjusts some field parts based on TI formating
+function _getElement( field,type='id' ){
+  const el = type=='id' ? document.getElementById(field) 
+           : document.getElementsByName(field.replace('-','_') + (field.includes('[') ? ']' : '') )[0];
+  return el;
+}
+
+// function to attach google autocomplete to some html element (and fill it's associated form fields)
+function attachAutocomplete( input, type='id', namePrefix='' ) {
+    if( !google || !google.maps || !google.maps.places ){
+      console.log( `[autocomplete-js] GoogleMaps 'places' library not loaded, aborting.` );
+      if(intervalAutocomplete) clearInterval(intervalAutocomplete);
+      intervalAutocomplete = null;
+      return false;
+    }
+    console.log( `[autocomplete-js] attaching(${type=='id'?'id='+input.id:'name='+input.name})`);
+
+    try {
+      const autocomplete = new google.maps.places.Autocomplete(input);
+      // When the user selects an address from the dropdown, you can get more details about the place
+      autocomplete.addListener('place_changed', function () {
+        const place = autocomplete.getPlace();
+        if (!place.geometry) {
+          // User entered the name of a Place that was not suggested and pressed the Enter key
+          window.alert("No details available for input: '" + place.name + "'");
+          return;
+        }
+
+        const addressComponents = place.address_components;
+
+        const addressDetails = {
+          street: '',
+          city: '',
+          state: '',
+          country: '',
+          postcode: '',
+          locationId: place.place_id,
+          latitude: place.geometry.location.lat(),
+          longitude: place.geometry.location.lng()
+        };
+
+        // decode google's info block to an addressDetails block we can map to form fields
+        addressComponents.forEach(component => {
+          const types = component.types;
+          if (types.includes('street_number')) {
+            addressDetails.street = component.long_name + ' ' + addressDetails.street;
+          }
+          if (types.includes('route')) {
+            addressDetails.street += component.long_name;
+          }
+          if (types.includes('locality')) {
+            addressDetails.city = component.long_name;
+          } else if( addressDetails.city==='' && types.includes('administrative_area_level_2')){
+            addressDetails.city = component.long_name;
+          }
+          if (types.includes('administrative_area_level_1')) {
+            addressDetails.state = component.long_name;
+          }
+          if (types.includes('country')) {
+            addressDetails.country = component.long_name;
+          }
+          if (types.includes('postal_code')) {
+            addressDetails.postcode = component.long_name;
+          }
+        });
+        // console.log( ` .. extracted from google addressComponents: `, addressComponents ) // if debugging see Google's fields here
+
+        // fill in details on the form
+        input.value = addressDetails.street;
+        ['city','state','postcode'].forEach( name=>{
+          const el = _getElement(namePrefix+name,type); // type=='id' ? document.getElementById(namePrefix+name) : document.getElementByName(namePrefix+name+']');
+          if( el ){
+            console.log( `[autocomplete-js] field[${type=='id'?'id='+el.id:'name='+el.name}]='${addressDetails[name]}'` );
+            el.value = addressDetails[name]
+          } else {
+            console.log( `[autocomplete-js] invalid element for ${name}!`)
+          }
+        })
+        
+        const elSelect = type=='id' && namePrefix=='' && document.getElementById('country') ? document.getElementById('country') :
+                        _getElement(namePrefix+'country-id',type)
+        if( elSelect ){
+            for (let i = 0; i < elSelect.options.length; i++) {
+              if (elSelect.options[i].text.trim() == addressDetails.country) {
+                elSelect.selectedIndex = i;
+                elSelect.value = i+1;
+                // triggers update for BS modified SELECT boxes
+                elSelect.dispatchEvent(new Event('change'));
+                break;
+              }
+            }
+        }
+
+        console.log( `[autocomplete-js] Autocomplete finished; Location: ${addressDetails.latitude},${addressDetails.longitude}` );
+      });
+    } catch( e ){
+      console.log( `[autocomplete-js] Problem with autocomplete:`, e );
+    }
+}
+
+function autoBindAddressToAutocomplete(){
+    const els = document.getElementsByTagName('INPUT');
+    // console.log( `[autocomplete-js] els (${els.length})` )
+    for (let i = 0; i < els.length; i++) {
+        const el_name = els[i].name.toLowerCase();
+        if( el_name.includes('address_1') || el_name.includes('address_2') || el_name.includes('street') ){
+            const el = els[i];
+            const bindSet = el?.dataset?.autocomplete || false;
+            if( !bindSet ){
+              el.dataset['autocomplete'] = true; // mark as autocomplete attached
+              if( el.id ){
+                // if it's got an ID, then we can use that for all the form fields
+                // get the prefix being all the field-name up to that last 'address_1/2'
+                const namePrefix = el.id.substring(0,el.id.lastIndexOf('address'))
+                attachAutocomplete( el,'id', namePrefix )
+              } else {
+                // no ID, use the name field, and again determine prefix field-name
+                const namePrefix = el.name.substring(0,el.name.lastIndexOf('address'))
+                attachAutocomplete( el,'name', namePrefix )
+              }
+            }
+        }
+    }
+}
+
+// start scanning for address INPUT fields to attach autocomplete to, scans every 5s
+let intervalAutocomplete;
+document.addEventListener('DOMContentLoaded', ()=>{ intervalAutocomplete=setInterval(autoBindAddressToAutocomplete, 5000);autoBindAddressToAutocomplete(); });

--- a/bootstrap/https.php
+++ b/bootstrap/https.php
@@ -1,0 +1,14 @@
+<?php
+
+if( isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD']==='GET' ){
+
+    $is_https = (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] == 1))
+                || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https');
+
+    if( !$is_https && isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI']) ){
+        $redirect_url = "https://" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        header("Location: $redirect_url");
+        exit();
+    }
+}
+?>

--- a/index.php
+++ b/index.php
@@ -7,6 +7,9 @@
  * @author   Samuel Adepoyigi
  */
 
+// Require HTTPS:// calls when loading pages (GET calls)
+require __DIR__.'/bootstrap/https.php';
+
 /*
 |--------------------------------------------------------------------------
 | Register The Auto ClassLoader


### PR DESCRIPTION
Adjusting controller:Locations/Customers to inject autocomplete.js so that address-auto-completion works.

Autocomplete.js scans every 10 seconds for new fields with 'address_1|address_2|street' in them, and if found, attaches auto-complete to them.

This enhancement has been tested with various extensions too. They may need to have the google-maps + auto-complete libraries added to them for auto-completion.