### PR TITLE
Introducing TastyIgniter Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <a href="https://github.com/tastyigniter/TastyIgniter/blob/master/LICENSE.txt"><img src="https://img.shields.io/github/license/tastyigniter/TastyIgniter.svg?label=License&style=flat-square" alt="License"></a>
 <a href="https://crowdin.com/project/tastyigniter"><img src="https://badges.crowdin.net/tastyigniter/localized.svg" alt="Crowdin"></a>
 <a href="https://twitter.com/TastyIgniter"><img src="https://img.shields.io/twitter/follow/TastyIgniter.svg?label=Follow" alt="Twitter"></a>
+<a href="https://gurubase.io/g/tastyigniter"><img src="https://img.shields.io/badge/Gurubase-Ask%20TastyIgniter%20Guru-006BFF" alt="Gurubase"></a>
 </p>
 
 [TastyIgniter](https://tastyigniter.com/) provides a professional and reliable platform for restaurants wanting to offer


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [TastyIgniter Guru](https://gurubase.io/g/tastyigniter) to Gurubase. TastyIgniter Guru uses the data from this repo and data from the [docs](https://tastyigniter.com/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "TastyIgniter Guru", which highlights that TastyIgniter now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable TastyIgniter Guru in Gurubase, just let me know that's totally fine.
