### PR TITLE
Fix admin marketplace install: stop sending stale `ver` for install items

### DIFF
--- a/app/admin/assets/js/updates.js
+++ b/app/admin/assets/js/updates.js
@@ -128,12 +128,15 @@
             installedItems = this.options.installedItems
 
         this.$itemModal.find('.item-details').html(bodyHtml)
-        if (context.require.length && context.require.data.length) {
-            context.require = context.require.data.map(function (require) {
+        var requireData = context.require && context.require.data
+        if (requireData && requireData.length) {
+            context.require = requireData.map(function (require) {
                 return $.extend(require, {installed: ($.inArray(require.code, installedItems) > -1)})
             })
 
             this.$itemModal.find('.item-details').after(Mustache.render(Updates.TEMPLATES.modalRequire, context))
+        } else {
+            context.require = []
         }
 
         this.$itemModal.find('.modal-footer').html(footerHtml)
@@ -147,29 +150,29 @@
     }
 
     Updates.prototype.applyItemInModal = function ($modal) {
-        var self = this
+        var self = this,
+            action = this.options.itemInModal.action
 
         // push require first
-        if (this.options.itemInModal.require.length) {
-            this.options.itemInModal.require.map(function (require) {
+        var requires = this.options.itemInModal.require || []
+        if (requires.length) {
+            requires.map(function (require) {
                 if ($modal.find('[data-control="require-item"][data-item-code="' + require.code + '"].active').length < 1)
                     return
 
-                self.options.itemsToApply.push({
-                    name: require.code,
-                    type: require.type,
-                    ver: require.version,
-                    action: self.options.itemInModal.action
-                })
+                var item = {name: require.code, type: require.type, action: action}
+                if (action === 'update') item.ver = require.version
+                self.options.itemsToApply.push(item)
             })
         }
 
-        this.options.itemsToApply.push({
+        var item = {
             name: this.options.itemInModal.code,
             type: this.options.itemInModal.type,
-            ver: this.options.itemInModal.version,
-            action: this.options.itemInModal.action
-        })
+            action: action
+        }
+        if (action === 'update') item.ver = this.options.itemInModal.version
+        this.options.itemsToApply.push(item)
     }
 
     Updates.prototype.showProgressBar = function () {

--- a/app/system/traits/ManagesUpdates.php
+++ b/app/system/traits/ManagesUpdates.php
@@ -306,7 +306,7 @@ trait ManagesUpdates
         return $this->validate(post(), [
             'items.*.name' => ['required'],
             'items.*.type' => ['required', 'in:core,extension,theme,language'],
-            'items.*.ver' => ['required'],
+            'items.*.ver' => ['required_if:items.*.action,update'],
             'items.*.action' => ['required', 'in:install,update'],
         ], [], [
             'items.*.name' => lang('system::lang.updates.label_meta_code'),

--- a/app/system/views/updates/list_recommended.blade.php
+++ b/app/system/views/updates/list_recommended.blade.php
@@ -45,7 +45,6 @@
                         </div>
                         <input type="hidden" name="items[{{ $index }}][name]" value="{{ $item['code'] }}">
                         <input type="hidden" name="items[{{ $index }}][type]" value="{{ $item['type'] }}">
-                        <input type="hidden" name="items[{{ $index }}][ver]" value="{{ $item['version'] }}">
                         <input type="hidden" name="items[{{ $index }}][action]" value="install">
                     </div>
                 @endforeach


### PR DESCRIPTION
## Summary

The admin marketplace install flow has been broken: clicking **Install** on a recommended extension (or any extension found via marketplace search) ends with the misleading toast:

> The Meta Items field is required.

This PR fixes the root cause and a related JS error that prevented the marketplace-search install modal from working.

## Root cause

The hub `POST /core/apply` endpoint treats `items[*].ver` as **the version the client already has installed** and only returns items where something newer is available. The admin install flow was sending the *available* marketplace version as `ver` for `install` actions, so the hub thought the extension was already up to date and returned `{"data": []}`.

With an empty response, `buildProcessSteps()` still emits a `complete` step but with `items: []`. The `complete` step then fails `validateProcess()` because `meta.items` has the `required` rule, and the user sees "The Meta Items field is required."

The `extension:install` artisan command works because it sends `[name, type]` only — no `ver` — and so receives proper item data back.

## Changes

This PR aligns the admin UI with the same hub contract that the CLI already follows:

- **`app/admin/assets/js/updates.js`**
  - `applyItemInModal()` attaches `ver` only when `action === 'update'`. For install actions, `ver` has no meaning (nothing is installed yet) and confuses the hub.
  - `loadModal()` and the require-iteration in `applyItemInModal()` no longer crash on items whose hub payload omits `require`. This fixes a separate `Uncaught TypeError: Cannot read properties of undefined (reading 'length')` that broke the marketplace-search modal entirely.
- **`app/system/views/updates/list_recommended.blade.php`**
  - Drops the `items[*][ver]` hidden input from the recommended-install form. The form hard-codes `action="install"`, so `ver` was never semantically valid here.
- **`app/system/traits/ManagesUpdates.php`**
  - `validateItems()` makes `items.*.ver` `required_if:items.*.action,update` instead of unconditionally required.

The **update** path (`onApplyUpdateClick`, `data-control="update-item"`, modal updates) is untouched. Those items continue to send `ver` because it represents the currently-installed version, which is exactly what the hub expects for update calls.

## Test plan

- [x] Verified the upstream `https://api.tastyigniter.com/v2/core/apply` returns full item data when `ver` is omitted from the request, and `{"data": []}` when the available version is sent as `ver`.
- [x] Installed an extension via the **Marketplace → Recommended** install flow end-to-end on a fresh v3 install — download/extract/complete now all run successfully.
- [x] Marketplace-search → click extension → install modal renders without the JS `TypeError`, including for items that declare no `require` dependencies.
- [x] Updates check still functions: the `Update Now` button on outdated extensions still posts `ver` (current installed version) and receives upgrade items as before.
- [ ] Reviewer to verify on a TastyIgniter Pro / paid extension if available, since the hub's behavior may differ for licensed items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)